### PR TITLE
feat(prompts): FA path B1 thin (issue 006)

### DIFF
--- a/daily-advisor/prompt_phase6_fa_step1_classify.txt
+++ b/daily-advisor/prompt_phase6_fa_step1_classify.txt
@@ -4,9 +4,9 @@ You are {agent_id} in the Phase 6 multi-agent SP evaluation pipeline (FA line, s
 
 For each FA candidate, classify them against the team's anchor SP (the master's P1 from the my-team line) into exactly one of three buckets:
 
-- **`worth`** — clearly worth investigating as a replacement; ≥ 2 ✅ tags or strong overall edge with no strong warnings
-- **`not_worth`** — clearly not worth taking; gate-fail (Sum diff < 5 or < 3 positive slots), OR strong warning that caps weekly ceiling, OR structurally weaker on multiple axes
-- **`borderline`** — neither clearly worth nor clearly not; mixed signal, sample-too-small, role-ambiguous, partial upgrade
+- **`worth`** — clearly worth investigating as a replacement; multiple 5-slot percentile edges over the anchor with no strong warnings
+- **`not_worth`** — clearly not worth taking; structurally weaker than the anchor on multiple axes, or blocked by a strong role/sample warning
+- **`borderline`** — neither clearly worth nor clearly not; mixed 5-slot signal, sample-too-small, role-ambiguous, partial upgrade
 
 Output structured JSON.
 
@@ -17,22 +17,27 @@ Forced binary classifications make LLMs hedge by miscoding genuinely uncertain c
 ## Decision guidance
 
 1. **Anchor reference**: the my-team P1 SP is given in `anchor` with full v4 material. Compare each FA against this specific anchor — not against the whole team or generic "starter quality".
-2. **Use the gate as ground truth for `not_worth`**: Python pre-computes `win_gate_passed` (Sum diff ≥ 5 AND ≥ 3 positive slots). If `win_gate_passed` is False, classify `not_worth` unless you can articulate a non-Sum reason to upgrade (e.g. anchor has decline tag the gate missed). Don't override the gate without explicit reasoning.
+2. **Judge the FA from raw values + 5-slot percentiles**:
+   - ≥ 2 slots clearly better than the anchor, with no strong warning → usually `worth`
+   - 1 slot clearly better but 1-2 slots clearly worse → usually `borderline`
+   - multiple slots clearly worse than the anchor → usually `not_worth`
+   - When a percentile bucket and raw value feel in tension, cite the raw value and explain which one you trusted.
 3. **Strong warnings flip `worth` to `borderline` (or `not_worth`)**:
-   - ⚠️ 樣本小 (BBE < 30 or IP < 20) → minimum `borderline` even if Sum looks great (sample noise too high to trust)
+   - ⚠️ 樣本小 (BBE < 30 or IP < 20) → minimum `borderline` even if the visible slot profile looks great (sample noise too high to trust)
    - ⚠️ 短局 (IP/GS < 5.0) → caps weekly QS/IP ceiling regardless of contact quality
    - ⚠️ 上場有限 (IP/Team_G < 0.5) → can't accumulate stats even if quality is real
-   - ⚠️ IL 短期 (Yahoo IL10/IL15) → claim 後必須佔 IL slot，無法立即上場 → minimum `borderline`; only `worth` if a clear IL-stash case (anchor has slump-hold flag and FA is a 雙年 elite expected back ≤ 2 weeks). Default classification is `not_worth` — claiming IL FA wastes a weekly add slot (max 6/week).
-4. **Multiple ✅ with no ⚠️ → `worth`**:
-   - ≥ 2 ✅ tags (e.g. 雙年菁英 + 深投型) AND no ⚠️ → `worth`
-   - 1 ✅ + minor ⚠️ → `borderline` (let master decide)
+   - ⚠️ IL 短期 (Yahoo IL10/IL15) → claim 後必須佔 IL slot，無法立即上場 → minimum `borderline`; only `worth` if the raw profile is clearly superior and the roster context supports an IL stash. Default classification is `not_worth` — claiming IL FA wastes a weekly add slot (max 6/week).
+4. **Allowed tags are context, not verdicts**:
+   - ✅ 球隊主力 supports confidence that the role is stable.
+   - ⚠️ 上場有限 / ⚠️ 樣本小 / ⚠️ 短局 / ⚠️ IL 短期 / ⚠️ Swingman 角色 are sample or role warnings and can cap the verdict.
+   - Do not infer hidden evaluation tags; use the visible raw values and percentiles.
 5. **Cite specific numbers** in rationale, not generic phrases.
 6. **Don't hedge**: if your gut says borderline, mark borderline. The format encourages it. Don't pick `worth` reluctantly.
 
 ## Inputs you receive
 
-- `anchor`: the master's P1 SP (the comparison reference) with v4 breakdown, tags, season + prior data
-- `fa_candidates`: array of FA candidates, each with v4 breakdown, sum_diff vs anchor, win_gate_passed, add_tags, warn_tags, season + prior data, recent transactions / %owned trends
+- `anchor`: the master's P1 SP (the comparison reference) with 5-slot raw values + percentiles, context, tags, season + prior data, and 21d rolling signal
+- `fa_candidates`: array of FA candidates, each with 5-slot raw values + percentiles, add_tags, warn_tags, season + prior data, 21d rolling signal, and recent transactions / %owned trends
 
 ## Output format (strict JSON, no prose outside the fence)
 
@@ -42,7 +47,7 @@ Forced binary classifications make LLMs hedge by miscoding genuinely uncertain c
     {
       "name": "FA candidate name",
       "verdict": "worth" | "not_worth" | "borderline",
-      "rationale": "≤60 words. Cite ≥1 specific number. State the dominant factor (e.g. 'Sum diff 18 + 雙年菁英 + 深投型, no ⚠️' or 'gate-fail Sum diff 3' or 'Sum diff 15 but ⚠️ 樣本小 BBE 24')."
+      "rationale": "≤60 words. Cite ≥1 specific number. State the dominant factor (e.g. 'Whiff% P78 and xwOBACON .312 beat anchor .390, no strong ⚠️' or 'IP/GS P35 plus ⚠️ 短局 caps QS/IP')."
     }
     // ... one entry per FA candidate, in the same order as input
   ],

--- a/daily-advisor/prompt_phase6_fa_step2_rank.txt
+++ b/daily-advisor/prompt_phase6_fa_step2_rank.txt
@@ -2,22 +2,25 @@ You are the **master Claude** in the Phase 6 multi-agent SP evaluation pipeline 
 
 ## Your task (FA Step 2)
 
-Rank the surviving FA candidates from **top1 (best add target)** down (max top3) and emit borderline_pairs flagging any consecutive pair whose `sum_diff` gap is < 5 (the v4 borderline threshold reused from sp_step2_master). The top1 you output is the primary upgrade candidate that final_decision will compare one-on-one against the anchor.
+Rank the surviving FA candidates from **top1 (best add target)** down (max top3) and emit borderline_pairs for consecutive pairs whose raw 5-slot evidence is genuinely close or conflicted. The top1 you output is the primary upgrade candidate that final_decision will compare one-on-one against the anchor.
 
 You are NOT a vote-counter on classifications. The agents already classified; your job is to **rank within survivors**:
 
-1. **Identify the strongest add target** — clearest Sum diff, most ✅ tags, no strong ⚠️.
-2. **Identify the weakest survivor** — borderline-classified or 1✅+1⚠️ cases that barely passed step 1.
-3. **Catch potential blind spots** — if all 3 agents missed a structural signal you can see in the material (e.g. missed a strong warning, missed a slump-hold pattern, anchored on Sum and missed a raw-value diff), correct it and explain.
+1. **Identify the strongest add target** — clearest raw + percentile edge, stable role, no strong ⚠️.
+2. **Identify the weakest survivor** — borderline-classified or strong-warning cases that barely passed step 1.
+3. **Catch potential blind spots** — if all 3 agents missed a structural signal you can see in the material (e.g. missed a strong warning, missed a slump-hold pattern, missed a raw-value diff), correct it and explain.
 4. **Avoid weak aggregation** — if 2/3 agents called X "worth" but the 1 dissenting agent has a sharper rationale citing data the 2 missed, downgrade X to mid-rank or drop to top3 last position. State why explicitly.
 
 ## Decision guidance
 
 1. **The top1 you output IS the primary FA upgrade candidate downstream**. final_decision will compare anchor vs top1/top2/top3 one-on-one — top1 quality is most consequential.
 2. **§7.2 spike finding (2026-04-26)**: real data shows agents converge strongly when v4 material is rich; full agreement does NOT add information beyond what one agent says. Look for divergence and why.
-3. **Borderline gate**: if any pair of consecutive ranked positions has `sum_diff` gap < 5 in the underlying v4 data, mark `borderline_pairs` with that pair (e.g. ["top1-top2"]) so step 3 reviewers know where to scrutinize. Anchor-vs-top1 differences are NOT counted here — only intra-FA-ranking gaps.
+3. **Borderline pairs are your judgment call from raw material**. Mark consecutive ranked positions in `borderline_pairs` when the evidence is close or conflicted, not because of any pre-computed threshold. Examples:
+   - top1 has xwOBACON P80 but IP/GS P30, while top2 has balanced P55-P65 slots → `top1-top2` is worth review.
+   - top1 and top2 differ on only one meaningful slot, with similar role/sample warnings → `top1-top2` is worth review.
+   Anchor-vs-top1 differences are NOT counted here — only intra-FA-ranking pairs.
 4. **borderline-classified FAs (1 worth + 1 not_worth + 1 borderline)** must rank at top3 or get cut from the ranking entirely if there are ≥ 3 cleanly-classified worth candidates ahead of them.
-5. **Strong warnings** (⚠️ 短局 / 上場有限 / 樣本小 / IL 短期) on a candidate normally rank them lower despite OK Sum, because they cap weekly ceiling regardless of contact quality. ⚠️ IL 短期 specifically means the FA cannot start playing immediately (claim must occupy IL slot); rank below any healthy candidate of comparable Sum unless this is a clear IL-stash case (anchor on slump-hold + FA is 雙年 elite expected back ≤ 2 weeks).
+5. **Strong warnings** (⚠️ 短局 / 上場有限 / 樣本小 / IL 短期) on a candidate normally rank them lower despite good quality indicators, because they cap weekly ceiling regardless of contact quality. ⚠️ IL 短期 specifically means the FA cannot start playing immediately (claim must occupy IL slot); rank below any healthy candidate of comparable raw profile unless this is a clear IL-stash case.
 6. **Tight rationale** — 1-2 sentences per slot. Quote specific numerics. Reference agents' arguments only when they meaningfully affected your ranking (e.g. "agent_2's xwOBACON .312 emphasis was right — top1"). Don't pad with "all agents agreed" sentences.
 
 ## Inputs you receive
@@ -25,7 +28,7 @@ You are NOT a vote-counter on classifications. The agents already classified; yo
 - `agents_step1`: array of 3 agent outputs from FA classify, each containing `classifications` (per-FA verdicts + rationale), `agent_id`
 - `aggregated_verdicts`: Python pre-computed `{fa_name: "worth" | "not_worth" | "borderline"}` dict (≥ 2 vote majority)
 - `anchor`: the team's P1 SP (from my-team line) with full v4 material
-- `fa_survivors`: array of FA candidates that passed step 1 aggregation (verdicts ∈ {worth, borderline}), each with `name`, v4 breakdown, sum_diff vs anchor, win_gate_passed, add_tags, warn_tags, season + prior data, recent transactions / %owned trends
+- `fa_survivors`: array of FA candidates that passed step 1 aggregation (verdicts ∈ {worth, borderline}), each with `name`, 5-slot raw values + percentiles, add_tags, warn_tags, season + prior data, 21d rolling signal, and recent transactions / %owned trends
 
 ## Output format (strict JSON, no prose outside the fence)
 
@@ -35,13 +38,12 @@ You are NOT a vote-counter on classifications. The agents already classified; yo
     {
       "name": "FA candidate name",
       "rank": 1,
-      "sum_diff": 18,
       "classify_verdict": "worth",
-      "rationale": "≤80 words. Cite specific numerics + reference agent reasoning where it changed your ranking. Bad: 'best candidate'. Good: 'top1 — Sum +18 with 雙年菁英 + 深投型, no ⚠️; agent_2's xwOBACON .312 vs anchor .390 emphasis confirms structural quality'."
+      "rationale": "≤80 words. Cite specific numerics + reference agent reasoning where it changed your ranking. Bad: 'best candidate'. Good: 'top1 — Whiff% P78 and xwOBACON .312 beat anchor .390, no strong ⚠️; agent_2's contact-quality emphasis confirms structural quality'."
     }
     // ... up to 3 entries (max), in rank order 1, 2, 3
   ],
-  "agent_consensus": "Summarize agent agreement pattern in 1 sentence — e.g. 'all 3 agents called all FAs worth' OR 'split: agent_1/agent_2 worth on X, agent_3 borderline citing 樣本小 — I sided with majority because [reason]' OR '2/3 worth on Y, 1 not_worth — I downgraded Y to top3 because [reason]'.",
+  "agent_consensus": "Describe agent agreement pattern in 1 sentence — e.g. 'all 3 agents called all FAs worth' OR 'split: agent_1/agent_2 worth on X, agent_3 borderline citing 樣本小 — I sided with majority because [reason]' OR '2/3 worth on Y, 1 not_worth — I downgraded Y to top3 because [reason]'.",
   "borderline_pairs": ["top1-top2"] or [],
   "decision_notes": "Optional: one sentence on any structural blind spot you caught that 0 agents flagged, or 'none' if all agents covered the key signals."
 }
@@ -50,7 +52,7 @@ You are NOT a vote-counter on classifications. The agents already classified; yo
 Rules:
 - `ranked_top` must contain 1-3 entries (no more), in `rank` order ascending from 1.
 - All entries must have name from `fa_survivors[].name` exactly (no duplicates, no inventing).
-- `sum_diff` and `classify_verdict` echo the values from input — they are summaries, not your judgments.
-- `borderline_pairs` uses position labels like "top1-top2", "top2-top3" — empty list if no consecutive pair has Sum gap < 5. If ranked_top has only 1 entry, `borderline_pairs` MUST be `[]`.
-- If all `fa_survivors` look mediocre (no candidate has Sum diff ≥ 5 vs anchor), still output a `ranked_top` with at least 1 entry — final_decision will downgrade to `pass` action if needed. Don't return empty `ranked_top` here.
+- `classify_verdict` echoes the aggregated value from input — it is context, not a substitute for your ranking judgment.
+- `borderline_pairs` uses position labels like "top1-top2", "top2-top3" — empty list if no consecutive pair deserves review. If ranked_top has only 1 entry, `borderline_pairs` MUST be `[]`.
+- If all `fa_survivors` look mediocre, still output a `ranked_top` with at least 1 entry — final_decision will downgrade to `pass` action if needed. Don't return empty `ranked_top` here.
 - Output ONLY the JSON object inside a fenced code block. No prose before or after.

--- a/daily-advisor/prompt_phase6_fa_step3_review.txt
+++ b/daily-advisor/prompt_phase6_fa_step3_review.txt
@@ -9,7 +9,7 @@ Decide whether you agree with the master's `ranked_top`, with **specific focus o
 - `master_decision`: the master Claude's ranked_top, agent_consensus, borderline_pairs, decision_notes
 - `your_step1`: your own step 1 output (your original FA classifications + rationale)
 - `anchor`: the team's P1 SP (FA comparison reference) with full v4 material
-- `material`: the original v4 fixture (FA candidates with full Sum breakdowns, urgency factors, tags, prior_stats, etc.)
+- `material`: the original v4 fixture (FA candidates with 5-slot raw values + percentiles, tags, prior_stats, rolling signal, and role/sample context)
 
 You **do NOT see** the other 2 agents' step 1 outputs or rationales. This is intentional (per design doc §7.4=B): you can self-compare against your own original judgment, but you stay isolated from peers to preserve diversity.
 
@@ -20,7 +20,7 @@ You **do NOT see** the other 2 agents' step 1 outputs or rationales. This is int
 3. **You may dissent**. If the master picked something you find unjustified for top1 (e.g. they overruled the majority on weak grounds, or missed a structural signal that's clear in the material, or they ranked a borderline-classified FA above a clean-worth FA), mark `agree_on_top1: false` and explain in `dissent_reason`.
 4. **Classify-vs-rank consistency**. If your step 1 marked X as not_worth but master ranked X at top1, that's strong dissent material — articulate why X is structurally weaker. Conversely, if your step 1 marked X as worth and master ranked X at top1, this is concord.
 5. **Don't dissent for sport**. If your step 1 classification was already uncertain (you marked the candidate borderline) and master ranks it reasonably, concede.
-6. **IL stash check**. If master ranked a ⚠️ IL 短期 FA above any healthy candidate of comparable Sum, dissent unless the rationale explicitly justifies an IL stash (anchor slump-hold + 雙年 elite + ≤ 2 weeks return). Claiming an IL FA wastes a weekly add slot, so the bar is high.
+6. **IL stash check**. If master ranked a ⚠️ IL 短期 FA above any healthy candidate with a comparable raw profile, dissent unless the rationale explicitly justifies an IL stash. Claiming an IL FA wastes a weekly add slot, so the bar is high.
 7. **Re-evaluation cap**: orchestrator triggers at most 1 re-evaluation round if ≥ 2 reviewers dissent on top1 (`docs/fa_scan-claude-decision-layer-design.md` §7.3). If you dissent, your reason will be packaged for the master's re-evaluation pass — write it tight and actionable.
 
 ## Output format (strict JSON, no prose outside the fence)
@@ -29,7 +29,7 @@ You **do NOT see** the other 2 agents' step 1 outputs or rationales. This is int
 {
   "agree_on_full_ranking": true | false,
   "agree_on_top1": true | false,
-  "top1_assessment": "≤80 words. State whether the master's top1 is correct and why. Cite specific numerics from the material — not 'I disagree' but 'master picked X but Y has Sum diff +18 vs X's +6 with 2 ✅ tags, suggesting Y is the better top1'.",
+  "top1_assessment": "≤80 words. State whether the master's top1 is correct and why. Cite specific numerics from the material — not 'I disagree' but 'master picked X, but Y has Whiff% P78 and xwOBACON .312 vs X's P45/.370, suggesting Y is the better top1'.",
   "dissent_reason": "If agree_on_top1 is false, what specifically should change. ≤80 words. Be actionable — e.g. 'top1 should be Y not X because [signal]'. If agree_on_top1 is true, write 'none'.",
   "willing_to_concede": true | false,
   "concede_note": "If your step 1 classified differently (e.g. you said not_worth for the master's top1) but you now agree with the ranking, briefly explain what changed your mind. ≤40 words. Use 'n/a' if not applicable.",

--- a/daily-advisor/prompt_phase6_final_decision.txt
+++ b/daily-advisor/prompt_phase6_final_decision.txt
@@ -11,25 +11,26 @@ Output exactly one of three actions:
 ## Inputs you receive
 
 - `anchor`: the team's P1 weakest SP (full v4 material from the my-team line)
-- `fa_top`: array of 1-3 top FA candidates that passed classification + master ranking (each with v4 material, sum_diff, tags, recent context like %owned trends / acquisitions)
+- `fa_top`: array of 1-3 top FA candidates that passed classification + master ranking (each with 5-slot raw values + percentiles, tags, 21d rolling signal, and recent context like %owned trends / acquisitions)
 - `borderline_pairs`: from my-team master decision, e.g. `["P1-P2"]` — if the anchor itself is in a borderline pair, escalate caution
 - `non_data_context`: roster needs (positional pressure, BN flexibility), %owned acquisition pressure (3d+ jump indicating other GMs are watching), recent transactions, FAAB remaining
 
 ## Decision guidance
 
 1. **`drop_X_add_Y` requires a clear edge**:
-   - Sum diff ≥ 5 AND ≥ 3 of 5 slots positive (the v4 win gate)
-   - At least 2 ✅ tags OR strong overall edge
-   - No strong warnings (⚠️ 樣本小 / 短局 / 上場有限 / IL 短期) blocking the upgrade
-   - If the anchor has a slump-hold flag or recent positive trajectory signal, raise the bar — these are reasons to wait, not act
-   - **⚠️ IL 短期 (Yahoo IL10/IL15) on a FA is a hard block** unless the swap is a deliberate IL stash — claiming the FA forces it onto an IL slot, so it cannot start playing immediately and burns a weekly add slot (max 6/week). Default to `watch` or `pass`. Only `drop_X_add_Y` if all of: (a) anchor is on slump-hold or genuinely droppable, (b) FA is 雙年 elite (兩年 Sum ≥ 40 or equivalent skill profile), (c) expected return ≤ 2 weeks, (d) a free IL slot is available on our roster.
+   - Judge the upgrade from the 5-slot raw values + percentiles. Suggested bar: ≥ 2 slots clearly better than the anchor, with no strong warning blocking the move.
+   - Strong overall edge across the full profile, especially if contact quality and either innings or whiffs are both better.
+   - No strong warnings (⚠️ 樣本小 / 短局 / 上場有限 / IL 短期) blocking the upgrade.
+   - If the anchor has a slump-hold flag or recent positive trajectory signal, raise the bar — these are reasons to wait, not act.
+   - **⚠️ IL 短期 (Yahoo IL10/IL15) on a FA is a hard block** unless the swap is a deliberate IL stash — claiming the FA forces it onto an IL slot, so it cannot start playing immediately and burns a weekly add slot (max 6/week). Default to `watch` or `pass`. Only `drop_X_add_Y` if all of: (a) anchor is genuinely droppable, (b) FA's raw profile is clearly superior, (c) expected return ≤ 2 weeks, (d) a free IL slot is available on our roster.
+   - Allowed tag context: ✅ 球隊主力 supports role stability; ⚠️ 上場有限 / ⚠️ 樣本小 / ⚠️ 短局 / ⚠️ IL 短期 / ⚠️ Swingman 角色 are role or sample warnings.
 2. **`watch` is the right answer when**:
    - FA is genuinely close but missing one signal you'd want (e.g. K rate not yet up, sample still small)
    - %owned is low (no acquisition pressure) so you can wait one more start
    - Anchor has volatility either way that next start clarifies
 3. **`pass` is right when**:
-   - All FAs gate-fail or have strong warnings
-   - Anchor's structural baseline is genuinely above all FAs (Sum diff ≤ 0)
+   - All FAs have strong warnings or weaker raw profiles
+   - Anchor's structural baseline is genuinely above all FAs
    - The marginal upgrade isn't worth burning an acquisition slot
 4. **%owned pressure can elevate `watch` → `drop_X_add_Y`**:
    - If FA is `worth` per classification AND %owned 3d delta ≥ +10pp, the window is closing — bias toward action
@@ -37,15 +38,15 @@ Output exactly one of three actions:
 5. **Roster context matters for action vs watch**:
    - If team has empty BN slot or IL slot freed up, swap is cheaper (no drop pain)
    - If anchor is currently the best of a thin position group, swap risks structural hole
-6. **One sentence per reason in `reason` field**. Don't repeat the data — interpret it. Bad: 「Pfaadt Sum 37 vs Nola 19 = +18」. Good: 「Pfaadt 的 K 率終於追上 stuff，過去 BABIP 假象被打破 — Sum +18 是真升級，不是樣本噪音」.
+6. **One sentence per reason in `reason` field**. Don't repeat the data — interpret it. Bad: 「Pfaadt xwOBACON .312, Nola .390」. Good: 「Pfaadt 5-slot 中 4 項 percentile 高於 Nola，xwOBACON .312 vs .390，且沒有 ⚠️ 短局/樣本小，這是品質升級不是單場熱度。」
 
 ## Waiver-log integration
 
-The `waiver_log_updates` field is consumed downstream by `_update_waiver_log_locked()` to write NEW / UPDATE rows. Each entry must have:
+The `waiver_log_updates` field is read downstream by `_update_waiver_log_locked()` to write NEW / UPDATE rows. Each entry must have:
 
 - `action`: `"NEW"` or `"UPDATE"`
 - `name`: player name
-- `note`: one-line context (e.g. "added to watch — see 5/03 start", "rostered by us", "passed in 04-26 Phase 6 final decision — Sum 18 vs anchor but ⚠️ 樣本小")
+- `note`: one-line context (e.g. "added to watch — see 5/03 start", "rostered by us", "passed in 04-26 Phase 6 final decision — strong xwOBACON but ⚠️ 樣本小")
 
 If you choose `drop_X_add_Y`, emit:
 - UPDATE on dropped player (note: rationale for drop)
@@ -77,7 +78,7 @@ If you choose `pass`, emit no waiver_log_updates unless one of the FAs needs UPD
       "note": "繁體中文一行脈絡"
     }
   ],
-  "telegram_summary": "繁體中文，≤80 字（≤150 chars）。單行 Telegram 推送。格式：『[Phase 6] action — 短理由』。例：『[Phase 6] drop Nola add Pfaadt — Sum +18 雙年菁英，K 率追上 stuff』。"
+  "telegram_summary": "繁體中文，≤80 字（≤150 chars）。單行 Telegram 推送。格式：『[Phase 6] action — 短理由』。例：『[Phase 6] drop Nola add Pfaadt — xwOBACON 明顯勝出，K 率追上 stuff』。"
 }
 ```
 
@@ -87,6 +88,6 @@ Rules:
 - If `action` is `pass`, `drop` / `add` / `watch_target` MUST be null. `watch_triggers` MUST be empty array.
 - `reason` is mandatory regardless of action.
 - `telegram_summary` is mandatory and ≤ 150 chars (will be embedded in Telegram message).
-- **Language**: `reason` / `watch_triggers` / `waiver_log_updates.note` / `telegram_summary` 一律輸出繁體中文（臺灣用語）。技術術語（xERA、Whiff%、Sum、Barrel% 等）與球員名保留英文原文。其餘 JSON 欄位（`action` / `drop` / `add` / `watch_target` / `waiver_log_updates.action`）保持英文 enum 值。
+- **Language**: `reason` / `watch_triggers` / `waiver_log_updates.note` / `telegram_summary` 一律輸出繁體中文（臺灣用語）。技術術語（xERA、Whiff%、Barrel% 等）與球員名保留英文原文。其餘 JSON 欄位（`action` / `drop` / `add` / `watch_target` / `waiver_log_updates.action`）保持英文 enum 值。
 - `waiver_log_updates` may be empty array but the field must be present.
 - Output ONLY the JSON object inside a fenced code block.

--- a/daily-advisor/prompt_phase6_sp_step1_rank.txt
+++ b/daily-advisor/prompt_phase6_sp_step1_rank.txt
@@ -1,42 +1,47 @@
-You are {agent_id} in the Phase 6 multi-agent SP evaluation pipeline for a 12-team H2H 7×7 fantasy baseball league. The orchestrator runs 3 independent agents (agent_1 / agent_2 / agent_3) on this same task in parallel; a master Claude integrates your rankings in step 2; the same 3 agents review the master decision in step 3 and may trigger one round of re-evaluation.
+You are {agent_id} in the Phase 6 multi-agent SP evaluation pipeline for a 12-team H2H 7x7 fantasy baseball league. The orchestrator runs 3 independent agents (agent_1 / agent_2 / agent_3) on this same task in parallel; a master Claude integrates your rankings in step 2; the same 3 agents review the master decision in step 3 and may trigger one round of re-evaluation.
 
 ## Your task (Step 1)
 
-Rank the team's weakest 4 SPs from **P1 (most drop-worthy)** to **P4 (most hold-worthy)**, given the v4 framework material below. Output structured JSON. The P1 you pick becomes the anchor for FA comparison downstream — it is the single most consequential output.
+Rank the team's weakest 4 SPs from **P1 (most drop-worthy)** to **P4 (most hold-worthy)**, given the v4 framework material below. Output structured JSON. The P1 you pick becomes the anchor for FA comparison downstream, so treat that slot as the single most consequential output.
 
 ## Framework reminder (v4 from 2026-04-24 design)
 
-Sum 0-50, five independent slots scored 0-10 each:
+Use direct raw values plus percentile direction across five independent SP skills:
 
-- **IP/GS** — innings per start, P50 5.46 / P90 6.11
-- **Whiff%** — pitch-arsenal weighted swing-and-miss, P50 24.0 / P90 30.0
-- **BB/9** — control (reverse: lower better), P50 2.95 / P90 1.96
-- **GB%** — ground ball rate, P50 43.2 / P90 54.6
-- **xwOBACON** — on-contact xwOBA (reverse: lower better), P50 .370 / P90 .341
+- **IP/GS** — innings per start, higher is better; supports IP and QS volume.
+- **Whiff%** — pitch-arsenal weighted swing-and-miss, higher is better; supports K ceiling.
+- **BB/9** — control, lower is better; supports WHIP and blowup risk.
+- **GB%** — ground-ball rate, higher is better; supports contact management and efficiency.
+- **xwOBACON** — on-contact xwOBA, lower is better; isolates damage allowed when contact happens.
 
-Higher Sum = better current production. Sum gap < 5 is borderline; Sum gap ≥ 10 is structurally clear.
+Read the material as a full raw profile, not as a pre-ranked list. Compare:
 
-**Urgency factors** (already pre-computed per candidate by Python):
-1. 2026 Sum band (lower Sum → higher urgency)
-2. 2025 prior Sum (slump-hold flag if 2025 Sum ≥ 40 AND IP ≥ 50)
-3. 21d Δ xwOBACON raw (Python returns 0 — interpret raw delta yourself: |Δ| < 0.030 noise / 0.030-0.050 mid / ≥ 0.050 strong; BBE < 20 ignore signal)
-4. Luck regression (xera-era when BBE ≥ 40)
+- Current-season 5-slot raw values and percentiles.
+- Prior-year 5-slot raw values and percentiles, including prior IP as the reliability check.
+- 21d xwOBACON shape: `delta` near 0 is noise; about 0.030-0.050 is a real lean; 0.050+ is a strong directional flag if 21d BBE is credible. Ignore tiny 21d BBE samples.
+- Context fields such as xERA, ERA, BBE, IP, G, GS, K9, and WHIP when they clarify fantasy impact.
 
-**Tags**:
-- ✅ positive (雙年菁英 / 深投型 / 球隊主力 / 近況確認 / 撿便宜運氣)
-- ⚠️ warnings, with **strong warnings** flagged: 短局 / 上場有限 / 樣本小 — these can override modest Sum advantages
+**Tags you may use as context**:
+- ✅ 球隊主力 = role/playing-time confidence.
+- ⚠️ 上場有限 = role risk.
+- ⚠️ 樣本小 = signal reliability risk.
+- ⚠️ 短局 = QS/IP ceiling risk.
+- ⚠️ IL 短期 = availability risk.
+- ⚠️ Swingman 角色 = rotation stability risk.
 
-**7×7 H2H pitcher categories**: IP, W, K, ERA, WHIP, QS, SV+H. League is **soft-punt SV+H**; SP slot quality matters most for IP/W/K/ERA/WHIP/QS.
+These tags describe role or sample quality only. Do not treat a tag as a verdict; derive the baseball evaluation from the raw values and percentiles.
 
-## Decision guidance (from §7.4 of design doc)
+**7x7 H2H pitcher categories**: IP, W, K, ERA, WHIP, QS, SV+H. League is **soft-punt SV+H**; SP slot quality matters most for IP/W/K/ERA/WHIP/QS.
 
-1. **Independent judgment**. Two other agents are doing the same task in parallel — do NOT assume their answer or speculate about it. Step 3 review will let you reconsider with master decision context.
-2. **No hedging**. Each P1-P4 slot must be a single named candidate. Use the `key_uncertainty` field (described below) to flag borderline calls instead of hedging the ranking itself.
-3. **Cite specific numbers**. Quote exact slot scores (e.g. "Sum 23 with xwOBACON .424 < P25 .386"), avoid generic phrases like "weakest" or "looks bad".
-4. **When buckets disagree with raw values, trust raw values**. v4 Sum's discrete 0-10 buckets per slot have known boundaries — if two candidates have similar Sums but very different raw values on a key slot, the raw value is ground truth.
-5. **Slump hold candidates** are pre-flagged in the material (2025 Sum ≥ 40 + IP ≥ 50). They get hold preference unless 2026 trajectory is unambiguously worse.
-6. **Strong warnings** (短局 / 上場有限 / 樣本小) on a candidate normally raise drop urgency despite OK Sum, because they cap weekly ceiling.
-7. **Tight rationale**. One sentence per slot is fine, two max. Your rationale will be cross-referenced by reviewers in step 3, so write so a reviewer can quickly verify your specific numerics.
+## Decision guidance
+
+1. **Independent judgment**. Two other agents are doing the same task in parallel. Do not infer their answer or speculate about it. Step 3 review will let you reconsider with master decision context.
+2. **No hedging**. Each P1-P4 slot must be a single named candidate. Use the `key_uncertainty` field to flag close calls instead of hedging the ranking itself.
+3. **Cite specific numbers**. Quote exact raw values and percentiles, e.g. "xwOBACON .424 with low percentile and 21d delta +.055", rather than generic phrases like "weakest" or "looks bad".
+4. **Trust raw values plus percentiles directly**. There is no extra scoring layer in your input. If two candidates look close, compare the individual 5-slot raw values, percentile direction, prior-year evidence, and 21d trend.
+5. **Slump-hold reasoning is yours to infer**. A candidate with strong prior-year SP indicators and meaningful prior IP deserves hold preference unless the current-season raw profile and 21d trend show clear deterioration.
+6. **Role/sample warnings matter**. Short outings, limited role, small sample, IL risk, or swingman usage can raise drop priority because they cap weekly ceiling or reduce reliability.
+7. **Tight rationale**. One sentence per slot is fine, two max. Your rationale will be cross-referenced by reviewers in step 3, so write so a reviewer can quickly verify your numerics.
 
 ## Output format (strict JSON, no prose outside the fence)
 
@@ -44,12 +49,12 @@ Higher Sum = better current production. Sum gap < 5 is borderline; Sum gap ≥ 1
 {
   "ranking": ["P1 name", "P2 name", "P3 name", "P4 name"],
   "rationale": {
-    "P1": "Why this candidate is the most drop-worthy. Cite ≥2 specific numbers.",
-    "P2": "Why second. Cite ≥1 specific number.",
-    "P3": "Why third. Cite ≥1 specific number.",
-    "P4": "Why this is the most hold-worthy. Cite ≥1 specific number."
+    "P1": "Why this candidate is the most drop-worthy. Cite >=2 specific numbers.",
+    "P2": "Why second. Cite >=1 specific number.",
+    "P3": "Why third. Cite >=1 specific number.",
+    "P4": "Why this is the most hold-worthy. Cite >=1 specific number."
   },
-  "key_uncertainty": "One sentence on the borderline call you found hardest (e.g. 'P3 vs P4 was close — Cantillo BBE 35 vs Holmes UCL durability'). Use 'none' if all four positions felt clear.",
+  "key_uncertainty": "One sentence on the close call you found hardest. Use 'none' if all four positions felt clear.",
   "agent_id": "{agent_id}"
 }
 ```

--- a/daily-advisor/prompt_phase6_sp_step2_master.txt
+++ b/daily-advisor/prompt_phase6_sp_step2_master.txt
@@ -6,24 +6,26 @@ Integrate the 3 agents' rankings into a single final ranking, with rationale tha
 
 You are NOT a vote-counter. The agents provide three independent reads; your job is to:
 
-1. **Identify where they agree** — high-consensus picks are robust signal (likely correct, but check that they aren't all anchored on the same surface signal you can see overruled by deeper data).
-2. **Identify where they disagree** — borderline cases that need adjudication. You have full data; pick based on the strongest evidence, not by majority vote.
-3. **Catch potential blind spots** — if all 3 agents missed a structural signal you can see in the material (e.g. missed a strong warning, missed a slump hold flag, anchored on Sum and missed a raw-value diff), correct it and explain.
-4. **Avoid weak aggregation** — if 2/3 agents picked X for P1 but the 1 dissenting agent has a sharper rationale citing data the 2 missed, the dissenter wins. State why explicitly.
+1. **Identify where they agree** — high-consensus picks are useful signal, but still check whether all agents repeated the same shallow cue while missing deeper raw data.
+2. **Identify where they disagree** — close cases need adjudication. You have full data; pick based on the strongest evidence, not by majority vote.
+3. **Catch potential blind spots** — if all 3 agents missed a structural signal you can see in the material (for example role risk, sample risk, prior-year SP quality, or a sharp 21d xwOBACON change), correct it and explain.
+4. **Avoid weak aggregation** — if 2/3 agents picked X for P1 but the dissenting agent has a sharper rationale citing data the other 2 missed, the dissenter can win. State why explicitly.
 
 ## Decision guidance
 
 1. **The P1 you output IS the FA comparison anchor downstream**. It is the most consequential single output of this pipeline. Treat it accordingly.
-2. **§7.2 spike finding (2026-04-26)**: real data shows agents converge strongly when v4 material is rich; full agreement does NOT add information beyond what one agent says. Look for divergence and why.
-3. **Borderline gate**: if any pair of consecutive ranking positions has Sum gap < 5 in the underlying v4 data, mark `borderline_pairs` with that pair so step 3 reviewers know where to scrutinize.
-4. **Slump hold candidates** must stay at hold-priority (P3 or P4) unless 2026 trajectory is unambiguously worse than 2025.
-5. **Strong warnings** (短局 / 上場有限 / 樣本小) on a candidate normally raise drop urgency despite OK Sum.
-6. **Tight rationale** — 1-2 sentences per slot. Quote specific numerics. Reference agents' arguments only when they meaningfully affected your decision (e.g. "agent_2's xwOBACON .466 emphasis was right — P1"). Don't pad with "all agents agreed" sentences.
+2. **Real consensus needs data support**. Full agreement by the agents does not automatically add information beyond one strong read. Look for divergence, but also verify that agreement is grounded in raw values and percentiles.
+3. **Borderline review is your judgment call (H3)**. Mark `borderline_pairs` when the raw profile is internally conflicted or when adjacent candidates are materially close, so step 3 reviewers know where to scrutinize.
+4. **Raw-conflict example**: if the P1 candidate has xwOBACON percentile near P30 but IP/GS percentile near P85, that internal split is a valid reason to mark a borderline pair.
+5. **Close-profile example**: if P1 and P2 have all five slot percentiles within about 5 percentage points and similar prior-year evidence, mark that adjacent pair as borderline even if all agents ranked one first.
+6. **Prior-year quality matters**. A candidate with strong prior-year SP indicators and meaningful prior IP should stay closer to hold-priority unless the current-season raw profile and 21d trend show clear deterioration.
+7. **Role/sample warnings matter**. 短局 / 上場有限 / 樣本小 / IL 短期 / Swingman 角色 can raise drop priority because they cap weekly ceiling or reduce reliability.
+8. **Tight rationale** — 1-2 sentences per slot. Quote specific numerics. Reference agents' arguments only when they meaningfully affected your decision.
 
 ## Inputs you receive
 
 - `agents_step1`: array of 3 agent outputs from step 1, each containing `ranking`, `rationale`, `key_uncertainty`, `agent_id`
-- `material`: the original v4 fixture (4 candidates with full Sum breakdowns, urgency factors, tags, prior_stats, etc.)
+- `material`: the original v4 fixture with candidates, 5-slot raw values and percentiles, prior-year material, 21d xwOBACON trend, role/sample tags, and context fields
 
 ## Output format (strict JSON, no prose outside the fence)
 
@@ -31,12 +33,12 @@ You are NOT a vote-counter. The agents provide three independent reads; your job
 {
   "final_ranking": ["P1 name", "P2 name", "P3 name", "P4 name"],
   "rationale": {
-    "P1": "Final rationale, ≤120 words. Cite specific numerics + reference agent reasoning where it changed your call.",
-    "P2": "≤100 words.",
-    "P3": "≤100 words.",
-    "P4": "≤80 words."
+    "P1": "Final rationale, <=120 words. Cite specific numerics + reference agent reasoning where it changed your call.",
+    "P2": "<=100 words.",
+    "P3": "<=100 words.",
+    "P4": "<=80 words."
   },
-  "agent_consensus": "Summarize agent agreement pattern in 1 sentence — e.g. 'all 3 agree on full ranking' OR '3/3 agree on P1 (López) but split on P3/P4 (Cantillo vs Holmes)' OR '2/3 picked Nola for P1, agent_2 picked López citing xwOBACON .466 — I sided with agent_2 because [reason]'.",
+  "agent_consensus": "Describe agent agreement pattern in 1 sentence, e.g. 'all 3 agree on full ranking' OR '3/3 agree on P1 (López) but split on P3/P4 (Cantillo vs Holmes)' OR '2/3 picked Nola for P1, agent_2 picked López citing xwOBACON .466 — I sided with agent_2 because [reason]'.",
   "borderline_pairs": ["P3-P4"] or [],
   "decision_notes": "Optional: one sentence on any structural blind spot you caught that 0 agents flagged, or 'none' if all agents covered the key signals."
 }
@@ -45,5 +47,5 @@ You are NOT a vote-counter. The agents provide three independent reads; your job
 Rules:
 - `final_ranking` must contain exactly 4 names from the original candidates list, no duplicates.
 - Names must match `material.candidates[].name` exactly.
-- `borderline_pairs` uses position labels like "P1-P2", "P2-P3", etc. — empty list if no consecutive pair has Sum gap < 5.
+- `borderline_pairs` uses position labels like "P1-P2", "P2-P3", etc.; use an empty list if no adjacent pair needs extra scrutiny.
 - Output ONLY the JSON object inside a fenced code block.

--- a/daily-advisor/prompt_phase6_sp_step3_review.txt
+++ b/daily-advisor/prompt_phase6_sp_step3_review.txt
@@ -8,17 +8,17 @@ Decide whether you agree with the master's `final_ranking`, with **specific focu
 
 - `master_decision`: the master Claude's final_ranking, rationale, agent_consensus, borderline_pairs, decision_notes
 - `your_step1`: your own step 1 output (your original ranking, rationale, key_uncertainty)
-- `material`: the original v4 fixture
+- `material`: the original v4 fixture with raw values, percentiles, prior-year material, 21d trend, and role/sample context
 
-You **do NOT see** the other 2 agents' step 1 outputs or rationales. This is intentional (per design doc §7.4=B): you can self-compare against your own original judgment, but you stay isolated from peers to preserve diversity.
+You **do NOT see** the other 2 agents' step 1 outputs or rationales. This is intentional: you can self-compare against your own original judgment, but you stay isolated from peers to preserve diversity.
 
 ## Decision guidance
 
 1. **Focus on P1 first**. Disagreement on P2-P4 is acceptable noise; disagreement on P1 is significant because it changes the FA comparison anchor downstream.
-2. **You may concede**. If the master's reasoning surfaces a signal you missed in step 1 (e.g. they cited a tag or raw value you didn't weigh), it's correct to mark `agree_on_p1: true` and acknowledge `willing_to_concede: true`. This is not a betrayal of your step 1 self.
-3. **You may dissent**. If the master picked something you find unjustified (e.g. they overruled the majority on weak grounds, or missed a structural signal that's clear in the material), mark `agree_on_p1: false` and explain in `dissent_reason`.
+2. **You may concede**. If the master's reasoning surfaces a raw value, percentile, prior-year signal, 21d trend, or role/sample warning you did not weigh enough in step 1, mark `agree_on_p1: true` and acknowledge `willing_to_concede: true`.
+3. **You may dissent**. If the master picked something you find unjustified (for example they overruled better raw evidence, ignored prior-year quality, or missed a clear role/sample cap), mark `agree_on_p1: false` and explain in `dissent_reason`.
 4. **Don't dissent for sport**. If your step 1 had `key_uncertainty` flagging the same call, and the master's pick is reasonable given the data, concede.
-5. **Re-evaluation cap**: orchestrator triggers at most 1 re-evaluation round if ≥ 2 reviewers dissent on P1 (`docs/fa_scan-claude-decision-layer-design.md` §7.3). If you dissent, your reason will be packaged for the master's re-evaluation pass — write it tight and actionable.
+5. **Re-evaluation cap**: orchestrator triggers at most 1 re-evaluation round if at least 2 reviewers dissent on P1. If you dissent, your reason will be packaged for the master's re-evaluation pass, so write it tight and actionable.
 
 ## Output format (strict JSON, no prose outside the fence)
 
@@ -26,16 +26,16 @@ You **do NOT see** the other 2 agents' step 1 outputs or rationales. This is int
 {
   "agree_on_full_ranking": true | false,
   "agree_on_p1": true | false,
-  "p1_assessment": "≤80 words. State whether the master's P1 is correct and why. Cite specific numerics from the material — not 'I disagree' but 'master picked X but Y has xwOBACON .466 vs X's .424, suggesting Y is structurally worse'.",
-  "dissent_reason": "If agree_on_p1 is false, what specifically should change. ≤80 words. Be actionable — e.g. 'P1 should be Y not X because [signal]'. If agree_on_p1 is true, write 'none'.",
+  "p1_assessment": "<=80 words. State whether the master's P1 is correct and why. Cite specific numerics from the material, e.g. 'master picked X but Y has xwOBACON .466 vs X's .424, suggesting Y is structurally worse'.",
+  "dissent_reason": "If agree_on_p1 is false, what specifically should change. <=80 words. Be actionable, e.g. 'P1 should be Y not X because [signal]'. If agree_on_p1 is true, write 'none'.",
   "willing_to_concede": true | false,
-  "concede_note": "If your step 1 picked differently but you now agree with master, briefly explain what changed your mind. ≤40 words. Use 'n/a' if not applicable.",
+  "concede_note": "If your step 1 picked differently but you now agree with master, briefly explain what changed your mind. <=40 words. Use 'n/a' if not applicable.",
   "agent_id": "{agent_id}"
 }
 ```
 
 Rules:
-- `agree_on_p1` is the critical field — orchestrator counts it for the re-evaluation gate.
-- `agree_on_full_ranking` is informational only (P2-P4 disagreement does not trigger re-evaluation per §7.2 spike-revised).
+- `agree_on_p1` is the critical field; orchestrator counts it for the re-evaluation gate.
+- `agree_on_full_ranking` is informational only (P2-P4 disagreement does not trigger re-evaluation).
 - Be honest about concession. If you genuinely changed your mind, say so. If you still think your step 1 was right but accept the master's call, say that too (`agree_on_p1: false, willing_to_concede: false` is valid).
 - Output ONLY the JSON object inside a fenced code block.


### PR DESCRIPTION
Reference: `issues/006-fa-path-prompt-b1.md`

Change log:
- Updated FA classify prompt to remove mechanical gate fields and guide reasoning from raw 5-slot values, percentiles, and surviving role/sample tags.
- Updated FA rank prompt to remove precomputed gap fields and make borderline pairs an LLM judgment from raw evidence.
- Cleaned FA review and final decision prompts so they no longer cite mechanical scoring anchors or removed evaluation tags.

Validation:
- Banned-word grep only reports the expected `telegram_summary` schema field hits.
- Banned-word grep filtered with `grep -vi summary` produced no output.
- `uv run --with pytest pytest daily-advisor/tests/` passed: 237 tests.
