### PR TITLE
feat: spike baseline scaffolding (issue 008a)

### DIFF
--- a/daily-advisor/_phase6_sp.py
+++ b/daily-advisor/_phase6_sp.py
@@ -62,6 +62,25 @@ def _load_prompt(name: str) -> str:
     return (_MODULE_DIR / fname).read_text(encoding="utf-8")
 
 
+def _dump_fixture(args, today_str: str, suffix: str, payload_str: str) -> None:
+    """Capture LLM payload as spike fixture (issue 008 baseline collection).
+
+    Writes <args.capture_payload>/<today_str>_<suffix>.json. No-op if flag unset.
+    Failure is non-fatal — production fa-scan continues regardless.
+    """
+    capture_dir = getattr(args, "capture_payload", None)
+    if not isinstance(capture_dir, str) or not capture_dir:
+        return
+    try:
+        out_dir = Path(capture_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{today_str}_{suffix}.json"
+        out_path.write_text(payload_str, encoding="utf-8")
+        print(f"  capture: wrote {out_path}", file=sys.stderr)
+    except Exception as e:
+        print(f"  capture: failed to dump {suffix}: {e}", file=sys.stderr)
+
+
 # ── v4 data attachment ──
 
 def _attach_v4_to_my_roster(my_roster: list[dict]) -> None:
@@ -319,6 +338,7 @@ def process_sp_v4(config, savant_2026, enriched, watch_enriched,
         print(f"  Layer 5 ({label}): step 1 — 3 agents rank P1-P4 in parallel...",
               file=sys.stderr)
         step1_payload = _build_step1_payload(urgency_result, low_conf)
+        _dump_fixture(args, today_str, "sp_step1", step1_payload)
         step1_results = run_parallel_agents(
             _load_prompt("sp_step1"), step1_payload, n_agents=3, timeout=_PHASE6_TIMEOUT,
         )
@@ -393,6 +413,7 @@ def process_sp_v4(config, savant_2026, enriched, watch_enriched,
         # === FA line ===
         print(f"  Layer 5 ({label}): step 4 — FA classify (3 agents)...", file=sys.stderr)
         fa_classify_payload = _build_fa_classify_payload(anchor_entry, fa_tagged)
+        _dump_fixture(args, today_str, "fa_classify", fa_classify_payload)
         fa_classify_results = run_parallel_agents(
             _load_prompt("fa_classify"), fa_classify_payload,
             n_agents=3, timeout=_PHASE6_TIMEOUT,

--- a/daily-advisor/_tools/fixtures/b1_baseline/2026-05-04_fa_classify.json
+++ b/daily-advisor/_tools/fixtures/b1_baseline/2026-05-04_fa_classify.json
@@ -1,0 +1,197 @@
+{
+  "_provenance": {
+    "case": "fa-scan #149 (2026-05-04 SP-v4) — FA classify hand-composed for issue 008 baseline spike",
+    "source": "Reconstructed from #149 issue body fa_rank.ranked_top + agent rationale + 2025 SP v4 percentile table in CLAUDE.md",
+    "anchor": "Cole Ragans (master P1 from SP step1; B1 anchor for FA comparison)",
+    "ground_truth_master_top1": "Casey Mize (3/3 worth, Sum diff +9, BB/9 3.19 fixes anchor's worst slot)",
+    "fa_pool_note": "Production #149 had 12 FA candidates. Reconstruction kept 4 with deepest rationale data (Mize / McCullers / Lambert / Fedde). Small pool acceptable for historical baseline; deviation from production scale documented."
+  },
+  "anchor": {
+    "name": "Cole Ragans",
+    "team": "KC",
+    "position": "SP",
+    "selected_pos": "SP",
+    "status": null,
+    "season_v4": {
+      "slots": {
+        "IP/GS": {"raw": 5.0, "percentile": 0, "_estimated": true},
+        "Whiff%": {"raw": 30.7, "percentile": 95},
+        "BB/9": {"raw": 5.85, "percentile": 0},
+        "GB%": {"raw": 36.0, "percentile": 0, "_estimated": true},
+        "xwOBACON": {"raw": 0.455, "percentile": 0}
+      },
+      "context": {"xera": 5.33, "era": 5.29, "bbe": 76, "ip": 30.0, "g": 6, "gs": 6, "k9": 11.4, "whip": 1.55}
+    },
+    "prior_v4": {
+      "ip": null,
+      "slots": {
+        "IP/GS": {"raw": null, "percentile": null},
+        "Whiff%": {"raw": null, "percentile": null},
+        "BB/9": {"raw": 4.5, "percentile": 0, "_estimated": true},
+        "GB%": {"raw": null, "percentile": null},
+        "xwOBACON": {"raw": null, "percentile": null}
+      }
+    },
+    "rolling_21d": {"xwobacon": null, "season_xwobacon": 0.455, "delta": null, "bbe": null},
+    "pa_tags": [],
+    "sample_tags": [],
+    "add_tags": [],
+    "warn_tags": [],
+    "low_confidence": false,
+    "notes": ["Per #149: anchor with structural weakness BB/9 5.85 + xwOBACON .455 dual-year"]
+  },
+  "fa_candidates": [
+    {
+      "name": "Casey Mize",
+      "team": "DET",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": 3.19, "percentile": 25},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        },
+        "context": {"xera": null, "era": null, "bbe": 81, "ip": null, "g": 6, "gs": 6, "k9": null, "whip": null}
+      },
+      "prior_v4": {
+        "ip": null,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        }
+      },
+      "rolling_21d": {"xwobacon": 0.288, "season_xwobacon": null, "delta": null, "bbe": 81},
+      "pa_tags": ["✅ 球隊主力"],
+      "sample_tags": [],
+      "add_tags": ["✅ 球隊主力"],
+      "warn_tags": [],
+      "low_confidence": false,
+      "notes": ["Per #149: Sum diff +9 vs anchor; 21d xwOBACON .288 elite trending confirmed; 6 GS = locked rotation"],
+      "pct": null,
+      "d1": null,
+      "d3": null,
+      "waiver_date": null
+    },
+    {
+      "name": "Lance McCullers Jr.",
+      "team": "HOU",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": 26.9, "percentile": 60},
+          "BB/9": {"raw": 4.88, "percentile": 0},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        },
+        "context": {"xera": 4.40, "era": 6.32, "bbe": null, "ip": null, "g": 6, "gs": 6, "k9": null, "whip": null}
+      },
+      "prior_v4": {
+        "ip": null,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        }
+      },
+      "rolling_21d": {"xwobacon": 0.331, "season_xwobacon": null, "delta": null, "bbe": null},
+      "pa_tags": ["✅ 球隊主力"],
+      "sample_tags": [],
+      "add_tags": ["✅ 球隊主力"],
+      "warn_tags": [],
+      "low_confidence": false,
+      "notes": ["Per #149: ERA 6.32 vs xERA 4.40 = -1.92 buy-low; BB/9 4.88 mirrors anchor weakness"],
+      "pct": null,
+      "d1": null,
+      "d3": null,
+      "waiver_date": null
+    },
+    {
+      "name": "Peter Lambert",
+      "team": "COL",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": 5.0, "percentile": 0, "_estimated": true},
+          "Whiff%": {"raw": 33.8, "percentile": 95},
+          "BB/9": {"raw": 4.11, "percentile": 0},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": 0.310, "percentile": 95}
+        },
+        "context": {"xera": null, "era": null, "bbe": 38, "ip": 15, "g": 3, "gs": 3, "k9": null, "whip": null}
+      },
+      "prior_v4": {
+        "ip": null,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        }
+      },
+      "rolling_21d": {"xwobacon": null, "season_xwobacon": 0.310, "delta": null, "bbe": null},
+      "pa_tags": [],
+      "sample_tags": ["⚠️ 樣本小"],
+      "add_tags": [],
+      "warn_tags": ["⚠️ 樣本小"],
+      "low_confidence": true,
+      "notes": ["Per #149: BBE 38 / 3 GS / 15 IP = small sample; elite Whiff/xwOBACON ceiling but unverified"],
+      "pct": null,
+      "d1": null,
+      "d3": null,
+      "waiver_date": null
+    },
+    {
+      "name": "Erick Fedde",
+      "team": "STL",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": 16.9, "percentile": 0},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": 0.300, "percentile": 95}
+        },
+        "context": {"xera": null, "era": null, "bbe": null, "ip": null, "g": null, "gs": null, "k9": 5.94, "whip": null}
+      },
+      "prior_v4": {
+        "ip": null,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        }
+      },
+      "rolling_21d": {"xwobacon": null, "season_xwobacon": 0.300, "delta": null, "bbe": null},
+      "pa_tags": [],
+      "sample_tags": [],
+      "add_tags": [],
+      "warn_tags": [],
+      "low_confidence": false,
+      "notes": ["Per #149: elite xwOBACON .300 P90+ but Whiff% 16.9 / K/9 5.94 = K-category structural hole"],
+      "pct": null,
+      "d1": null,
+      "d3": null,
+      "waiver_date": null
+    }
+  ]
+}

--- a/daily-advisor/_tools/fixtures/b1_baseline/2026-05-04_sp_step1.json
+++ b/daily-advisor/_tools/fixtures/b1_baseline/2026-05-04_sp_step1.json
@@ -1,0 +1,216 @@
+{
+  "_provenance": {
+    "case": "fa-scan #149 (2026-05-04 SP-v4) — hand-composed for issue 008 baseline spike",
+    "source": "Reconstructed from #149 issue body agent rationale + 2025 SP v4 percentile table in CLAUDE.md",
+    "intent": "Known anchor failure case — under v4-thick prompts (production at time of #149), 3 agents lazy-anchored on Sum 14 / 19 numbers. Re-running with B1 thin prompts measures whether independent reasoning emerges.",
+    "ground_truth_master_p1": "Cole Ragans (3/3 step1 P1 + master) — high-confidence drop, structurally weak in 2 slots both years",
+    "missing_fields": "Some 5-slot raw values (e.g. Ragans IP/GS, Cantillo IP/GS) not cited in rationale; estimated from reverse-Sum and marked _estimated. 2025 prior breakdown for non-Nola candidates partial.",
+    "shape_notes": "Matches payload_slimmer.slim_entry(role='my_team') schema. percentile uses fa_compute._v4_percentile bucket logic (≥P90 → 95, otherwise band match)."
+  },
+  "candidates": [
+    {
+      "name": "Cole Ragans",
+      "team": "KC",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": 5.0, "percentile": 0, "_estimated": true},
+          "Whiff%": {"raw": 30.7, "percentile": 95},
+          "BB/9": {"raw": 5.85, "percentile": 0},
+          "GB%": {"raw": 36.0, "percentile": 0, "_estimated": true},
+          "xwOBACON": {"raw": 0.455, "percentile": 0}
+        },
+        "context": {
+          "xera": 5.33,
+          "era": 5.29,
+          "bbe": 76,
+          "ip": 30.0,
+          "g": 6,
+          "gs": 6,
+          "k9": 11.4,
+          "whip": 1.55
+        }
+      },
+      "prior_v4": {
+        "ip": null,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": 4.5, "percentile": 0, "_estimated": true},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        }
+      },
+      "rolling_21d": {
+        "xwobacon": null,
+        "season_xwobacon": 0.455,
+        "delta": null,
+        "bbe": null
+      },
+      "pa_tags": [],
+      "sample_tags": [],
+      "add_tags": [],
+      "warn_tags": [],
+      "low_confidence": false,
+      "notes": ["Per #149: 2025 prior Sum 17 — BB/9 already poor; not a slump, structural"]
+    },
+    {
+      "name": "Aaron Nola",
+      "team": "PHI",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": 3.73, "percentile": 0},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": 0.425, "percentile": 0}
+        },
+        "context": {
+          "xera": 4.86,
+          "era": 6.03,
+          "bbe": 92,
+          "ip": null,
+          "g": null,
+          "gs": null,
+          "k9": null,
+          "whip": null
+        }
+      },
+      "prior_v4": {
+        "ip": 94.3,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": 0.382, "percentile": 0}
+        }
+      },
+      "rolling_21d": {
+        "xwobacon": null,
+        "season_xwobacon": 0.425,
+        "delta": null,
+        "bbe": null
+      },
+      "pa_tags": [],
+      "sample_tags": [],
+      "add_tags": [],
+      "warn_tags": [],
+      "low_confidence": false,
+      "notes": [
+        "Per #149: 2025 prior Sum 14, 275 BBE — dual-year structural weakness on xwOBACON",
+        "Luck factor: xERA 4.86 vs ERA 6.03 = -1.17 (slight buy-low signal but underlying poor)"
+      ]
+    },
+    {
+      "name": "JR Ritchie",
+      "team": "ATL",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": 6.17, "percentile": 95},
+          "Whiff%": {"raw": 19.3, "percentile": 0},
+          "BB/9": {"raw": 4.38, "percentile": 0},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": 0.389, "percentile": 0}
+        },
+        "context": {
+          "xera": null,
+          "era": null,
+          "bbe": 34,
+          "ip": null,
+          "g": 2,
+          "gs": 2,
+          "k9": null,
+          "whip": null
+        }
+      },
+      "prior_v4": {
+        "ip": null,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": null, "percentile": null}
+        }
+      },
+      "rolling_21d": {
+        "xwobacon": null,
+        "season_xwobacon": 0.389,
+        "delta": null,
+        "bbe": null
+      },
+      "pa_tags": [],
+      "sample_tags": ["⚠️ 樣本小"],
+      "add_tags": [],
+      "warn_tags": ["⚠️ 樣本小"],
+      "low_confidence": true,
+      "notes": [
+        "Per #149: only 2 GS / BBE 34 — extreme small sample, no 2025 prior",
+        "Elite IP/GS but Whiff%/BB/9 both <P25 — true quality unknown until more starts"
+      ]
+    },
+    {
+      "name": "Joey Cantillo",
+      "team": "CLE",
+      "position": "SP",
+      "selected_pos": "SP",
+      "status": null,
+      "season_v4": {
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": 26.0, "percentile": 60},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": 45.7, "percentile": 60},
+          "xwOBACON": {"raw": null, "percentile": null}
+        },
+        "context": {
+          "xera": null,
+          "era": null,
+          "bbe": null,
+          "ip": null,
+          "g": null,
+          "gs": null,
+          "k9": null,
+          "whip": null
+        }
+      },
+      "prior_v4": {
+        "ip": 95.3,
+        "slots": {
+          "IP/GS": {"raw": null, "percentile": null},
+          "Whiff%": {"raw": null, "percentile": null},
+          "BB/9": {"raw": null, "percentile": null},
+          "GB%": {"raw": null, "percentile": null},
+          "xwOBACON": {"raw": 0.364, "percentile": 60}
+        }
+      },
+      "rolling_21d": {
+        "xwobacon": null,
+        "season_xwobacon": null,
+        "delta": 0.039,
+        "bbe": 59
+      },
+      "pa_tags": [],
+      "sample_tags": [],
+      "add_tags": [],
+      "warn_tags": [],
+      "low_confidence": false,
+      "notes": [
+        "Per #149: 2025 prior Sum 22 with 95 IP, xwOBACON .364 (P70) — solid structural floor",
+        "21d Δ xwOBACON +0.039 BBE 59 = mid-range deterioration, credible signal but not decisive",
+        "Highest in pool by master verdict — hold candidate"
+      ]
+    }
+  ],
+  "slump_hold_excluded": [],
+  "low_confidence_excluded": []
+}

--- a/daily-advisor/_tools/spike_b1_baseline.py
+++ b/daily-advisor/_tools/spike_b1_baseline.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""spike_b1_baseline — Issue 008 baseline spike runner (B1 prompts, full mini-pipeline).
+
+Re-runs Phase 6 SP + FA path against captured fixtures using the current B1-thin
+prompts to measure baseline consensus rates. Unlike the older `multi_agent_spike.py`
+(step 1 only), this runs both step 1 (3 agents) AND step 2 master per path so we
+can capture both M1 (P1 match rate) and M4 (master borderline trigger rate).
+
+Per-case pipeline:
+  SP path:
+    1. SP step1 — 3 parallel agents on `<date>_sp_step1.json`        → M1 SP
+    2. SP step2 master — 1 master call (3 agents output + material)  → M4 SP
+  FA path:
+    3. FA classify — 3 parallel agents on `<date>_fa_classify.json`
+    4. FA rank master — 1 master call (3 verdicts + survivors)
+       M1 FA = did all 3 step1 agents classify master's top1 as 'worth'
+       M4 FA = master.borderline_pairs non-empty
+
+Output: per-case JSON to stdout + aggregate stats (mean/std) to stderr.
+
+Usage (from daily-advisor/):
+  python3 _tools/spike_b1_baseline.py --fixture-dir _tools/fixtures/b1_baseline
+  python3 _tools/spike_b1_baseline.py --fixture-dir DIR --cases 2026-05-04 2026-05-08
+  python3 _tools/spike_b1_baseline.py --fixture-dir DIR --skip-fa  # SP only
+
+WARNING: 4 claude -p calls per case for SP path + 4 for FA = 8/case. 7 cases ≈ 56
+calls against subscription. Don't run unsupervised.
+
+Refs: issues/008-spike-fixture-baseline.md, docs/sp-b1-baseline.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Re-use production helpers — import paths assume cwd=daily-advisor/
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from _multi_agent import (  # noqa: E402
+    aggregate_classifications,
+    all_parsed,
+    consensus_check_key,
+    run_parallel_agents,
+    run_single_agent,
+)
+
+_MODULE_DIR = Path(__file__).resolve().parent.parent
+_TIMEOUT = 600
+
+
+def _load_prompt(fname: str) -> str:
+    return (_MODULE_DIR / fname).read_text(encoding="utf-8")
+
+
+def _list_cases(fixture_dir: Path) -> list[str]:
+    """Return sorted list of dates that have BOTH sp_step1 + fa_classify fixtures."""
+    sp_dates = {f.stem.removesuffix("_sp_step1")
+                for f in fixture_dir.glob("*_sp_step1.json")}
+    fa_dates = {f.stem.removesuffix("_fa_classify")
+                for f in fixture_dir.glob("*_fa_classify.json")}
+    return sorted(sp_dates & fa_dates)
+
+
+def _run_sp_path(case: str, sp_step1_payload: str) -> dict:
+    """Run SP step1 (3 agents) + step2 master. Return per-case metrics."""
+    t0 = time.time()
+    print(f"  [{case}] SP step1: 3 agents...", file=sys.stderr)
+    step1_results = run_parallel_agents(
+        _load_prompt("prompt_phase6_sp_step1_rank.txt"),
+        sp_step1_payload, n_agents=3, timeout=_TIMEOUT,
+    )
+
+    parsed_count = sum(1 for r in step1_results if r.parsed is not None)
+    sp_p1_match = None
+    sp_p1_distribution = None
+    if all_parsed(step1_results):
+        match, info = consensus_check_key(step1_results, ["ranking", 0])
+        sp_p1_match = match
+        sp_p1_distribution = info["distribution"]
+
+    sp_master_borderline = None
+    sp_master_p1 = None
+    sp_borderline_pairs = None
+    master_parsed = False
+    if parsed_count > 0:
+        # Build step2 payload (mirrors _phase6_sp._build_step2_payload)
+        material = json.loads(sp_step1_payload)
+        step2_obj = {
+            "agents_step1": [
+                {"agent_id": r.agent_id, **(r.parsed or {"error": r.error})}
+                for r in step1_results
+            ],
+            "material": material,
+        }
+        step2_payload = json.dumps(step2_obj, ensure_ascii=False, indent=2,
+                                   default=str)
+        print(f"  [{case}] SP step2 master...", file=sys.stderr)
+        master = run_single_agent(
+            _load_prompt("prompt_phase6_sp_step2_master.txt") + "\n\n---\n\n" + step2_payload,
+            "master", timeout=_TIMEOUT,
+        )
+        if master.parsed is not None:
+            master_parsed = True
+            sp_borderline_pairs = master.parsed.get("borderline_pairs") or []
+            sp_master_borderline = bool(sp_borderline_pairs)
+            sp_master_p1 = (master.parsed.get("final_ranking") or [None])[0]
+
+    return {
+        "case": case,
+        "sp_step1_parsed": parsed_count,
+        "sp_p1_match": sp_p1_match,
+        "sp_p1_distribution": sp_p1_distribution,
+        "sp_master_parsed": master_parsed,
+        "sp_master_p1": sp_master_p1,
+        "sp_master_borderline": sp_master_borderline,
+        "sp_borderline_pairs": sp_borderline_pairs,
+        "sp_path_seconds": round(time.time() - t0, 1),
+    }
+
+
+def _run_fa_path(case: str, fa_classify_payload: str) -> dict:
+    """Run FA classify (3 agents) + rank master. Return per-case metrics."""
+    t0 = time.time()
+    print(f"  [{case}] FA classify: 3 agents...", file=sys.stderr)
+    classify_results = run_parallel_agents(
+        _load_prompt("prompt_phase6_fa_step1_classify.txt"),
+        fa_classify_payload, n_agents=3, timeout=_TIMEOUT,
+    )
+    parsed_count = sum(1 for r in classify_results if r.parsed is not None)
+
+    # Aggregate classify into worth/borderline survivors
+    payload_obj = json.loads(fa_classify_payload)
+    fa_names = [f["name"] for f in payload_obj.get("fa_candidates", [])]
+    aggregated = aggregate_classifications(classify_results, fa_names)
+    survivors_lookup = {
+        f["name"]: f for f in payload_obj.get("fa_candidates", [])
+        if aggregated.get(f["name"]) in ("worth", "borderline")
+    }
+
+    fa_master_top1 = None
+    fa_master_borderline = None
+    fa_borderline_pairs = None
+    fa_master_parsed = False
+    fa_top1_unanimous_worth = None
+
+    if not survivors_lookup:
+        print(f"  [{case}] FA: 0 survivors after classify aggregation, skipping master",
+              file=sys.stderr)
+    elif parsed_count == 0:
+        print(f"  [{case}] FA: classify all parse-failed, skipping master",
+              file=sys.stderr)
+    else:
+        # Build rank master payload (mirrors _phase6_sp._build_fa_rank_payload)
+        rank_obj = {
+            "agents_step1": [
+                {"agent_id": r.agent_id, **(r.parsed or {"error": r.error})}
+                for r in classify_results
+            ],
+            "aggregated_verdicts": aggregated,
+            "anchor": payload_obj.get("anchor"),
+            "fa_survivors": list(survivors_lookup.values()),
+        }
+        rank_payload = json.dumps(rank_obj, ensure_ascii=False, indent=2,
+                                  default=str)
+        print(f"  [{case}] FA rank master ({len(survivors_lookup)} survivors)...",
+              file=sys.stderr)
+        master = run_single_agent(
+            _load_prompt("prompt_phase6_fa_step2_rank.txt") + "\n\n---\n\n" + rank_payload,
+            "fa_master", timeout=_TIMEOUT,
+        )
+        if master.parsed is not None:
+            fa_master_parsed = True
+            ranked_top = master.parsed.get("ranked_top") or []
+            if ranked_top:
+                fa_master_top1 = ranked_top[0].get("name")
+            fa_borderline_pairs = master.parsed.get("borderline_pairs") or []
+            fa_master_borderline = bool(fa_borderline_pairs)
+
+            # M1 FA = did all 3 classify agents classify master.top1 as 'worth'?
+            if fa_master_top1:
+                top1_verdicts = []
+                for r in classify_results:
+                    if r.parsed is None:
+                        continue
+                    for c in r.parsed.get("classifications", []) or []:
+                        if c.get("name") == fa_master_top1:
+                            top1_verdicts.append(c.get("verdict"))
+                            break
+                fa_top1_unanimous_worth = (
+                    len(top1_verdicts) == 3
+                    and all(v == "worth" for v in top1_verdicts)
+                )
+
+    return {
+        "case": case,
+        "fa_classify_parsed": parsed_count,
+        "fa_aggregated": aggregated,
+        "fa_survivors_count": len(survivors_lookup),
+        "fa_master_parsed": fa_master_parsed,
+        "fa_master_top1": fa_master_top1,
+        "fa_master_borderline": fa_master_borderline,
+        "fa_borderline_pairs": fa_borderline_pairs,
+        "fa_top1_unanimous_worth": fa_top1_unanimous_worth,
+        "fa_path_seconds": round(time.time() - t0, 1),
+    }
+
+
+def _aggregate_stats(per_case: list[dict], skip_fa: bool, skip_sp: bool) -> dict:
+    """Compute baseline mean/std for M1 + M4 across cases."""
+    def _rate(values: list[bool | None]) -> tuple[float | None, float | None, int]:
+        vals = [1.0 if v is True else 0.0 for v in values if v is not None]
+        if not vals:
+            return None, None, 0
+        mean = statistics.mean(vals)
+        # population std (single sample interpreted as one observation, so use stdev with n-1)
+        sd = statistics.stdev(vals) if len(vals) > 1 else 0.0
+        return round(mean, 3), round(sd, 3), len(vals)
+
+    summary: dict = {"n_cases": len(per_case)}
+    if not skip_sp:
+        m1_sp_mean, m1_sp_sd, n = _rate([c.get("sp_p1_match") for c in per_case])
+        m4_sp_mean, m4_sp_sd, _ = _rate([c.get("sp_master_borderline") for c in per_case])
+        summary["sp"] = {
+            "M1_p1_match_rate": {"mean": m1_sp_mean, "std": m1_sp_sd, "n": n},
+            "M4_master_borderline_rate": {"mean": m4_sp_mean, "std": m4_sp_sd, "n": n},
+            "M1_minus_1sd_threshold": (
+                round(m1_sp_mean - m1_sp_sd, 3)
+                if m1_sp_mean is not None and m1_sp_sd is not None else None
+            ),
+        }
+    if not skip_fa:
+        m1_fa_mean, m1_fa_sd, n = _rate([c.get("fa_top1_unanimous_worth") for c in per_case])
+        m4_fa_mean, m4_fa_sd, _ = _rate([c.get("fa_master_borderline") for c in per_case])
+        summary["fa"] = {
+            "M1_top1_unanimous_worth_rate": {"mean": m1_fa_mean, "std": m1_fa_sd, "n": n},
+            "M4_master_borderline_rate": {"mean": m4_fa_mean, "std": m4_fa_sd, "n": n},
+            "M1_minus_1sd_threshold": (
+                round(m1_fa_mean - m1_fa_sd, 3)
+                if m1_fa_mean is not None and m1_fa_sd is not None else None
+            ),
+        }
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--fixture-dir", required=True,
+                        help="Directory containing <date>_sp_step1.json + <date>_fa_classify.json pairs")
+    parser.add_argument("--cases", nargs="*",
+                        help="Specific case dates to run (default: all in dir)")
+    parser.add_argument("--skip-sp", action="store_true",
+                        help="Skip SP path (FA only)")
+    parser.add_argument("--skip-fa", action="store_true",
+                        help="Skip FA path (SP only)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List cases + estimated calls, don't invoke claude -p")
+    args = parser.parse_args()
+
+    fixture_dir = Path(args.fixture_dir)
+    if not fixture_dir.is_dir():
+        print(f"fixture-dir not found: {fixture_dir}", file=sys.stderr)
+        return 1
+
+    available = _list_cases(fixture_dir)
+    if args.cases:
+        cases = [c for c in args.cases if c in available]
+        missing = set(args.cases) - set(available)
+        if missing:
+            print(f"⚠️ skipping cases without complete fixture pairs: {sorted(missing)}",
+                  file=sys.stderr)
+    else:
+        cases = available
+
+    if not cases:
+        print("No complete fixture pairs found.", file=sys.stderr)
+        return 1
+
+    calls_per_case = (4 if not args.skip_sp else 0) + (4 if not args.skip_fa else 0)
+    total_calls = calls_per_case * len(cases)
+    print(f"Cases: {len(cases)} | calls/case: {calls_per_case} | total claude -p calls: {total_calls}",
+          file=sys.stderr)
+
+    if args.dry_run:
+        print("=== DRY RUN ===", file=sys.stderr)
+        for c in cases:
+            print(f"  {c}", file=sys.stderr)
+        return 0
+
+    per_case: list[dict] = []
+    for case in cases:
+        case_data: dict = {"case": case}
+        if not args.skip_sp:
+            sp_payload = (fixture_dir / f"{case}_sp_step1.json").read_text(encoding="utf-8")
+            case_data.update(_run_sp_path(case, sp_payload))
+        if not args.skip_fa:
+            fa_payload = (fixture_dir / f"{case}_fa_classify.json").read_text(encoding="utf-8")
+            case_data.update(_run_fa_path(case, fa_payload))
+        per_case.append(case_data)
+
+    summary = _aggregate_stats(per_case, args.skip_fa, args.skip_sp)
+
+    output = {"per_case": per_case, "baseline": summary}
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+
+    print(file=sys.stderr)
+    print("=== Baseline Summary ===", file=sys.stderr)
+    print(json.dumps(summary, indent=2, ensure_ascii=False), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -3585,6 +3585,8 @@ def main():
     parser.add_argument("--date", help="Override date YYYY-MM-DD")
     parser.add_argument("--include-inactive", action="store_true",
                         help="Stash mode: keep IL60/NA FA candidates (default: hard-filter)")
+    parser.add_argument("--capture-payload", metavar="DIR",
+                        help="Dump SP step1 + FA classify LLM payloads as spike fixtures (issue 008)")
     args = parser.parse_args()
 
     env = load_env()

--- a/docs/sp-b1-baseline.md
+++ b/docs/sp-b1-baseline.md
@@ -1,0 +1,125 @@
+# SP B1 Cutover — Baseline Spike Results
+
+> Issue: `issues/008-spike-fixture-baseline.md` · PRD: `issues/prd.md` · Design: `docs/sp-b1-cutover-design.md`
+
+## Status
+
+🟡 **In progress (2026-05-07)** — infra + #149 fixture ready; capture cron pending; awaiting 6-day fixture accumulation before final spike run.
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Spike runner extended (SP step1 + step2 + FA classify + rank) | ✅ | `daily-advisor/_tools/spike_b1_baseline.py` |
+| `fa_scan --capture-payload` flag | ✅ | commit `7603433` |
+| Case 1 fixture (#149 / 2026-05-04) | ✅ | hand-composed; gaps marked `_estimated` / null |
+| Cases 2-7 fixture | ⏳ | VPS daily capture from 2026-05-08 onwards |
+| Spike run (M1/M4 measurement) | ⏳ | Trigger after 7 cases |
+| Baseline numbers + thresholds | ⏳ | Mean / std / -1σ |
+| HITL review | ⏳ | User confirms baseline reasonable before issue 009 cutover |
+
+## Pipeline overview
+
+Per case (from one `<date>_sp_step1.json` + `<date>_fa_classify.json` fixture pair):
+
+```
+SP path:
+  SP step1 (3 agents in parallel)  →  M1 SP = all 3 agree on P1
+  SP step2 master (1 call)          →  M4 SP = master.borderline_pairs non-empty
+
+FA path:
+  FA classify (3 agents in parallel) →  per-FA verdicts (worth/borderline/not_worth)
+  FA rank master (1 call)             →  M4 FA = master.borderline_pairs non-empty
+                                         M1 FA = all 3 step1 classify master.top1 as 'worth'
+```
+
+Per-case cost: **8 claude -p calls** (4 SP + 4 FA). 7-case run ≈ **56 calls** against subscription rate limit.
+
+### M1 / M4 metric definitions
+
+| Metric | Definition | Source |
+|--------|------------|--------|
+| **M1 SP** | Boolean: 3 step1 agents return identical `ranking[0]` (P1 candidate). | `consensus_check_key(step1_results, ["ranking", 0])` |
+| **M4 SP** | Boolean: master step2 emits non-empty `borderline_pairs` (master self-judges raw signal conflict per H3). | `master.parsed["borderline_pairs"]` |
+| **M1 FA** | Boolean: all 3 step1 classify agents independently assigned master's `ranked_top[0]` candidate the verdict `"worth"` (= consensus on the eventual winner). | Cross-reference master output against per-agent classifications. |
+| **M4 FA** | Boolean: master step2 (`fa_step2_rank`) emits non-empty `borderline_pairs`. | `fa_master.parsed["borderline_pairs"]` |
+
+## Fixture inventory
+
+| Date | SP fixture | FA fixture | Provenance | Notes |
+|------|-----------|-----------|------------|-------|
+| 2026-05-04 | ✅ `2026-05-04_sp_step1.json` | ✅ `2026-05-04_fa_classify.json` | Hand-composed from #149 issue body | Sparse (5-slot raw mostly null for non-cited fields); `_estimated` flagged |
+| 2026-05-08 | ⏳ | ⏳ | VPS capture | First daily fixture after VPS deploy |
+| 2026-05-09 | ⏳ | ⏳ | VPS capture | |
+| 2026-05-10 | ⏳ | ⏳ | VPS capture | |
+| 2026-05-11 | ⏳ | ⏳ | VPS capture | |
+| 2026-05-12 | ⏳ | ⏳ | VPS capture | |
+| 2026-05-13 | ⏳ | ⏳ | VPS capture | (target 7 cases total) |
+
+> #149 reconstruction is the only "known anchor failure" anchor case. Other 6 are random daily snapshots — natural distribution should mix high-consensus and dispute cases.
+
+## Baseline results
+
+### Per-case raw
+
+⏳ Will populate after spike run. Format:
+
+| Date | M1 SP | SP master P1 | M4 SP | FA master top1 | M1 FA | M4 FA |
+|------|:---:|---|:---:|---|:---:|:---:|
+| 2026-05-04 | – | – | – | – | – | – |
+| ... | | | | | | |
+
+### Aggregate
+
+⏳ Mean / std across N=7. Format:
+
+| Path | Metric | Mean | Std | -1σ threshold |
+|------|--------|:---:|:---:|:---:|
+| SP | M1 P1 match | – | – | – |
+| SP | M4 master borderline | – | – | – |
+| FA | M1 top1 unanimous worth | – | – | – |
+| FA | M4 master borderline | – | – | – |
+
+## Retreat thresholds (set after baseline)
+
+Per `docs/sp-b1-cutover-design.md` §4 + PRD §"Further Notes":
+
+| Trigger | Condition | Action |
+|---------|-----------|--------|
+| **G1 — M1 collapse** | M1 SP weekly rate < (baseline -1σ) for **2 consecutive weeks** | Switch to single-LLM SP path (G-pre2 fallback). Ranking + final action condensed into one `prompt_phase6_sp_single.txt` call. |
+| **G1 alt — M4 over-trigger** | M4 SP weekly rate > **75%** for **2 consecutive weeks** | Same as above — master self-marking borderline >75% of weeks indicates raw payload itself is ambiguous. |
+
+> Numeric -1σ thresholds will be filled in after spike run. **Do not deploy `prompt_phase6_sp_single.txt` until trigger fires** (per F1: lazy fallback authoring — observation period 1-3 weeks may not need it).
+
+### G-pre2 fallback startup SOP (when triggered)
+
+1. Confirm trigger condition met (2 consecutive weeks data via `gh api` metric reader once issue 007 lands; manually until then).
+2. Open new branch `fix/g-pre2-sp-fallback`.
+3. Author `prompt_phase6_sp_single.txt` (single-call: input = anchor + FA pool + raw + percentile + 14d trad + %owned; output = `drop_X_add_Y` / `watch` / `pass` directly).
+4. Add `fallback_mode` flag to `_phase6_sp.process_sp_v4`; when true, dispatcher skips 8-step pipeline and runs single prompt.
+5. Switch the flag (config or env). Cron unchanged.
+6. Continue measuring M1/M4 dummy values (= 1.0/0.0, since single-call has no multi-agent dynamics) so dashboard still emits records.
+7. After 2 stable weeks on fallback, evaluate whether to keep multi-agent pipeline at all or remove permanently.
+
+## Known limitations
+
+- **Sparse #149 fixture**: rationale-derived raw values only; many 5-slot percentiles null. Spike P1 match on this case may overstate consensus (LLMs may converge on Ragans regardless because his cited weakness signals are stark — but also may diverge if missing fields produce hedging). Treat #149 result as anchor reference, not aggregate-defining.
+- **FA fixture pool size mismatch**: #149 production had 12 FA; reconstruction kept 4 (Mize/McCullers/Lambert/Fedde). Smaller pool may inflate consensus if borderline candidates dropped from reconstruction were the disagreement source.
+- **Subscription rate limit**: 56 calls in one run. Spread spike across 2-3 sessions if rate-limit guards trip.
+
+## Reproducing the spike
+
+```bash
+cd daily-advisor
+python3 _tools/spike_b1_baseline.py \
+    --fixture-dir _tools/fixtures/b1_baseline \
+    --dry-run                                  # preview cases + call count
+python3 _tools/spike_b1_baseline.py \
+    --fixture-dir _tools/fixtures/b1_baseline > spike_b1_baseline_results.json 2> spike_b1_baseline_stats.txt
+```
+
+Per-case JSON in stdout; aggregate stats to stderr (also at top of `--baseline` key in stdout JSON).
+
+## Decision log
+
+- **2026-05-07** Issue 008 kicked off. Fixture source = `--capture-payload` flag (not hand-compose all 7). #149 hand-compose with marked gaps as required spike anchor.
+- **2026-05-07** M4 measured (extended spike beyond multi_agent_spike step1-only). Both SP and FA paths included per acceptance.
+- **2026-05-07** Cases = 7 (issue 008 acceptance: 5-10 case + #149).


### PR DESCRIPTION
## Scope (008a — scaffolding only)

- `fa_scan --capture-payload` flag (opt-in, default off, no production behavior change)
- `_tools/spike_b1_baseline.py` — 8 calls/case spike runner (M1/M4 × SP/FA)
- `_tools/fixtures/b1_baseline/2026-05-04_*` — #149 hand-compose anchor (sparse, marked `_provenance`)
- `docs/sp-b1-baseline.md` skeleton (placeholder for numbers)

## NOT in this PR (008b follow-up after 6-day capture)

- 6 production-captured fixtures
- Spike run results + M1/M4 mean+std numbers
- Retreat thresholds (baseline -1σ)
- HITL review of baseline doc

## Why split (decided in main session 2026-05-07)

VPS needs the capture flag code to start collecting fixtures. Single-PR-with-6-day-draft creates a Catch-22. Scaffolding is opt-in, zero behavior change → safe to merge now and fill numbers via tiny follow-up PR.

## #149 fixture handling (decided for 008b)

Dual-track in baseline doc: report aggregate including #149 (7 cases) AND excluding #149 (6 cases, "production-only baseline"). #149 is design-intent anchor (PRD user story 12) but sparse — reader sees both numbers, threshold can use either.

## Test plan

- [ ] CI 跑 daily-advisor/tests/ 通過
- [ ] 用戶 self-review code 變更
- [ ] Capture flag opt-in 驗證：fa_scan 預設行為與 master 等價（不加 flag 時無 _tools/fixtures/b1_baseline/ 寫入）