### PR TITLE
chore(b1-baseline): cron wrapper for fixture capture + auto-push

### DIFF
--- a/daily-advisor/cron_capture_payload.sh
+++ b/daily-advisor/cron_capture_payload.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# fa_scan capture wrapper — runs daily fa-scan with --capture-payload, then
+# auto-commits new fixtures back to git so spike runner can consume them.
+#
+# Issue 008 (SP B1 cutover spike fixture baseline) followup: cron-side glue
+# so VPS-captured payloads land in the repo without manual sync.
+#
+# Cron usage (replaces the original `python3 daily-advisor/fa_scan.py ...` line):
+#   30 4 * * * root <env-setup> && bash /opt/mlb-fantasy/daily-advisor/cron_capture_payload.sh
+#
+# Logs:
+#   - fa_scan stdout/stderr → /var/log/fa-scan.log (unchanged)
+#   - wrapper status        → /var/log/fa-scan-capture.log
+
+set -uo pipefail
+
+REPO=/opt/mlb-fantasy
+FIXTURE_REL=daily-advisor/_tools/fixtures/b1_baseline
+FIXTURE_ABS="$REPO/$FIXTURE_REL"
+FA_LOG=/var/log/fa-scan.log
+WRAP_LOG=/var/log/fa-scan-capture.log
+
+ts() { date '+%F %T %Z'; }
+log() { echo "[$(ts)] $*" >> "$WRAP_LOG"; }
+
+cd "$REPO" || { log "FATAL: cd $REPO failed"; exit 1; }
+
+log "=== fa_scan capture run start ==="
+
+python3 daily-advisor/fa_scan.py --capture-payload "$FIXTURE_ABS" >> "$FA_LOG" 2>&1
+fa_rc=$?
+
+if [ $fa_rc -ne 0 ]; then
+    log "fa_scan exited $fa_rc — fixture push skipped"
+    exit $fa_rc
+fi
+
+new_files=$(git status --porcelain -- "$FIXTURE_REL" 2>/dev/null)
+if [ -z "$new_files" ]; then
+    log "no new/modified fixture in $FIXTURE_REL — nothing to push"
+    exit 0
+fi
+
+log "fixture changes detected:"
+echo "$new_files" >> "$WRAP_LOG"
+
+# Sync before push to avoid conflict with concurrent commits (waiver-log
+# auto-update, etc). fa_scan already pulled at startup but the cron tail
+# may have produced upstream changes since.
+if ! git pull --rebase origin master >> "$WRAP_LOG" 2>&1; then
+    log "git pull --rebase failed — abort + manual fix needed"
+    git rebase --abort >/dev/null 2>&1
+    exit 2
+fi
+
+git add "$FIXTURE_REL" >> "$WRAP_LOG" 2>&1
+today=$(date '+%Y-%m-%d')
+if ! git commit -m "chore(b1-baseline): capture fixture $today" >> "$WRAP_LOG" 2>&1; then
+    log "git commit failed (race? nothing staged after pull?) — exit clean"
+    exit 0
+fi
+
+if ! git push origin master >> "$WRAP_LOG" 2>&1; then
+    log "git push failed — manual intervention needed"
+    exit 3
+fi
+
+log "fixture committed + pushed OK"


### PR DESCRIPTION
## Summary
- New wrapper `daily-advisor/cron_capture_payload.sh` runs `fa_scan --capture-payload`, then detects new fixture files via git status and commits + pushes them to master
- Issue 008 followup: VPS-captured payloads currently sit on VPS forever; this closes the loop so spike runner + HITL review can consume them on the laptop side
- Production fa-scan logic unchanged (wrapper around existing CLI flag from PR #162)

## Test plan
- [x] Bash syntax check (`bash -n`)
- [ ] Manual trigger on VPS after merge: `bash /opt/mlb-fantasy/daily-advisor/cron_capture_payload.sh`
- [ ] Verify fixture file appears in `daily-advisor/_tools/fixtures/b1_baseline/` on VPS
- [ ] Verify auto-commit + push lands on master
- [ ] Verify local laptop sees fixture after `git pull`
- [ ] Update `/etc/cron.d/daily-advisor` to call wrapper instead of `fa_scan.py` directly

## Followup (post-merge)
1. Update VPS cron entry (TW 12:30 fa-scan) to call this wrapper
2. Wait 6 days for fixtures 2-7 to accumulate
3. Run `_tools/spike_b1_baseline.py` against full set
4. Fill in baseline numbers in `docs/sp-b1-baseline.md`
5. HITL review baseline → unblock issue 009 cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)