### PR TITLE
feat(fa_scan): FA batter sort by %owned desc, not vs-P1 sum_diff (issue 036)

### DIFF
--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -2903,6 +2903,27 @@ def _fmt_fa_block_batter_v4(entry: dict, idx: int | None,
     return lines
 
 
+def _sort_fa_by_owned(fa_tagged: list[dict]) -> list[dict]:
+    """Order FA batter candidates by %owned descending (issue 036).
+
+    The presentation order is the LLM's attention prior, so it must not
+    encode the system's own verdict. The previous key (vs-P1 ``sum_diff``
+    desc)膨脹 the whole batch's spread whenever our P1 anchor happened to be
+    weak — biasing which candidates got read first by a number derived from
+    our own roster. %owned is an external market signal orthogonal to our
+    judgment, consistent with batter v4 thin「Sum 不暴露、hint 非 verdict」.
+
+    Tie-break: name ascending for deterministic output. Entries missing
+    ``pct`` sort last (can't position them on the market axis).
+    """
+    def key(entry):
+        pct = entry.get("pct")
+        has_pct = isinstance(pct, (int, float))
+        return (0 if has_pct else 1, -(pct if has_pct else 0), entry.get("name", ""))
+
+    return sorted(fa_tagged, key=key)
+
+
 def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
                                  watch_tagged, changes, ref_1d, ref_3d, config,
                                  rostered_names=None):
@@ -2943,8 +2964,9 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
     # ── FA 候選 ──
     if fa_tagged:
         lines.append(f"\n--- FA 打者候選 ({len(fa_tagged)} 人，Sum≥21 通過品質門檻) ---")
-        # Sort: prefer larger Sum diff (still useful as ordering hint, not a verdict)
-        fa_sorted = sorted(fa_tagged, key=lambda x: -x.get("sum_diff", 0))
+        # Order by %owned desc (external market signal), NOT vs-P1 sum_diff —
+        # debias attention order when our own P1 anchor is weak (issue 036).
+        fa_sorted = _sort_fa_by_owned(fa_tagged)
         for idx, f in enumerate(fa_sorted, start=1):
             owned = enrich_owned_trend(f.get("name", ""), fa_history, today_str) \
                 if today_str else None

--- a/daily-advisor/tests/test_fa_sort_key.py
+++ b/daily-advisor/tests/test_fa_sort_key.py
@@ -1,0 +1,81 @@
+"""Unit tests for FA batter candidate sort key (issue 036).
+
+Presentation order is the LLM's attention prior, so it must use an external
+market signal (%owned desc), not the system's own vs-P1 sum_diff. See
+issues/036-fa-sort-key-debias.md.
+"""
+
+from fa_scan import _sort_fa_by_owned
+
+
+def _names(entries):
+    return [e["name"] for e in entries]
+
+
+def test_orders_by_owned_descending():
+    fa = [
+        {"name": "Low", "pct": 5, "sum_diff": 99},
+        {"name": "High", "pct": 60, "sum_diff": 0},
+        {"name": "Mid", "pct": 30, "sum_diff": 50},
+    ]
+    assert _names(_sort_fa_by_owned(fa)) == ["High", "Mid", "Low"]
+
+
+def test_sum_diff_does_not_influence_order():
+    # P1-weak scenario: huge sum_diff on a barely-owned player must NOT
+    # float it to the top.
+    fa = [
+        {"name": "Owned", "pct": 45, "sum_diff": 2},
+        {"name": "Inflated", "pct": 1, "sum_diff": 40},
+    ]
+    assert _names(_sort_fa_by_owned(fa)) == ["Owned", "Inflated"]
+
+
+def test_tie_break_by_name_ascending():
+    fa = [
+        {"name": "Zeb", "pct": 20, "sum_diff": 10},
+        {"name": "Abe", "pct": 20, "sum_diff": 1},
+        {"name": "Mac", "pct": 20, "sum_diff": 99},
+    ]
+    assert _names(_sort_fa_by_owned(fa)) == ["Abe", "Mac", "Zeb"]
+
+
+def test_missing_pct_sorts_last():
+    fa = [
+        {"name": "NoPct", "sum_diff": 99},
+        {"name": "NonePct", "pct": None, "sum_diff": 50},
+        {"name": "HasPct", "pct": 3, "sum_diff": 0},
+    ]
+    # HasPct (even at 3%) precedes both pct-less entries; pct-less broken by name.
+    assert _names(_sort_fa_by_owned(fa)) == ["HasPct", "NoPct", "NonePct"]
+
+
+def test_zero_pct_treated_as_real_value_not_missing():
+    fa = [
+        {"name": "Missing"},
+        {"name": "Zero", "pct": 0},
+    ]
+    # pct=0 is a real market value → ahead of a missing pct.
+    assert _names(_sort_fa_by_owned(fa)) == ["Zero", "Missing"]
+
+
+def test_float_pct_supported():
+    fa = [
+        {"name": "A", "pct": 12.5},
+        {"name": "B", "pct": 12.4},
+    ]
+    assert _names(_sort_fa_by_owned(fa)) == ["A", "B"]
+
+
+def test_empty_input():
+    assert _sort_fa_by_owned([]) == []
+
+
+def test_does_not_mutate_input():
+    fa = [
+        {"name": "B", "pct": 10},
+        {"name": "A", "pct": 90},
+    ]
+    original = list(fa)
+    _sort_fa_by_owned(fa)
+    assert fa == original  # original list order untouched

--- a/issues/prd-fa-scan-batter-quality.md
+++ b/issues/prd-fa-scan-batter-quality.md
@@ -20,7 +20,7 @@
 | [`033-payload-hygiene-pack`](033-payload-hygiene-pack.md) | AFK | 無 | ⏳ 未開工 |
 | [`034-pa-tg-gap-warn-tag`](034-pa-tg-gap-warn-tag.md) | AFK | 無 | ⏳ 未開工 |
 | [`035-woba-xwoba-luck-field`](035-woba-xwoba-luck-field.md) | AFK | 無 | ⏳ 未開工 |
-| [`036-fa-sort-key-debias`](036-fa-sort-key-debias.md) | AFK | 無 | ⏳ 未開工 |
+| [`036-fa-sort-key-debias`](036-fa-sort-key-debias.md) | AFK | 無 | ✅ 2026-06-10（merge `1604f33`） |
 | [`037-trigger-schema-constraint`](037-trigger-schema-constraint.md) | HITL | 028（同 prompt 分批上線） | ⏳ 未開工 |
 
 ### 開工順序（曆法長竿驅動）
@@ -33,6 +33,7 @@
 
 ### Handoff（最後更新：2026-06-10）
 
+- **036 完工（2026-06-10，merge `1604f33`）**：FA 打者候選呈現順序由 vs-P1 `sum_diff` 降序改 **%owned 降序**（外部市場訊號，與系統自身 verdict 正交）— 消除「P1 弱時整批機械分差膨脹、注意力順序被偏置」。抽純函式 `_sort_fa_by_owned`（name-asc tiebreak / 缺 pct 排末 / pct=0 視為真值），8 單測 `tests/test_fa_sort_key.py`。`pct` 來自 snapshot `percent_owned`，經 `_normalize_fa_for_compute` 帶上 fa_tagged。剩餘驗收：部署後隔日 issue payload 順序符合新鍵。
 - **現況**：**029 完工 merge（`0e94cf7`，2026-06-10）— batter 對帳骨架端到端打穿**：`_backtest_lib` 新增 batter 純函式層（028 文法 verdict 解析：ACTION→replace / 7 欄 NEW 帶 vs→watch，UPDATE/CLOSE/舊 6 欄不可對帳；episode key 取代/立即取代不拆帳；byDateRange 解析含「重複相同 splits」API quirk 去重 + 跨隊交易比率重算；六類別比數 R/HR/RBI/BB/AVG/OPS 無 SB）+ `backtest_batter.py` CLI（outcome 一律 pending-judge，週報 append `docs/batter-decisions-backtest.md`）+ `cron_backtest.sh` 擴充週日一次跑 SP + batter（單邊失敗仍 commit 健康側）。41 tests；對真實 archive dry-run 過（42 天 ~80 份 issue body 零誤報、輸出「0 筆可對帳」段 = 合格骨架輸出）。**曆法預期：batter 首筆新文法帳 = 2026-06-11 cron 產生，帳齡 21 達標日 ~07-02，首個可能非空週日段 = 2026-07-05**；SP 端首個非空 regular 段仍 = 2026-06-21；06-14 兩邊 0 筆屬正確行為。VPS 無需手動部署（每日 cron pull 會在 06-14 前帶上新 wrapper）。**030（裁判合議，HITL）/ 031（執行標註，AFK，可與 030 平行）已解鎖**。029 解析端注意：真實 production 新文法 issue（06-11 起）出現後，應補一份真實 production fixture 進 `test_backtest_batter.py`（目前新文法用 028 配對 A/B 的真實 LLM 輸出 `ab_028_b_result.json` 代位）。027 詳情：三破洞全修（header 定位 + 平衡大括號解析 / Savant outcome 補實 + MLB API id fallback / 帳齡 [21,28) episode 對帳）、5 個真實 issue fixture（#254/259/276/280/305）。028 詳情見下方「028 部署日」段。既存無關失敗：`test_pending_parser` 的活檔 fixture 漂移（master 同樣 fail，另案小修）。
 - **030 完工（2026-06-10，merge `b9a8e4d`）— 對帳回路全鏈打通（027→028→029→031→030 五片皆 ✅）**：pending-judge 升級 2 位裁判合議 verdict。純函式層 `build_judge_payload`（匿名 A/B、claim-blind、無 PA/G）/ `parse_judge_response`（強制二選一契約）/ `judge_consensus`（16 組合窮舉單測）/ `map_judge_outcome`（watch 鏡像：採用 A → miss、餘含難分 → hit 計分母）；邊界層 `run_judge_panel`（整週 1 payload × 2 judges claude -p neutral cwd，每週固定 2 calls + 各 1 retry，fail-open 留 pending-judge + ⚠️ 週報行）。週報每帳並列機械比數 + J1/J2 + 合議（稽核底稿）+ 命中率行（replace 量太衝動 / watch 量太保守）。第一批真 claude 抽查通過（真實 05-15→06-04 產出兩帳，零 retry、無唱反調；重測工具 `_tools/_judge_demo_runner.py`）。VPS 零部署動作（cron pull 自帶；cron PATH 已驗證含 claude）。**殘留觀察：07-05 首個非空 production 段出來後再人工抽查一次**（勉強/難分路徑尚未被真裁判走過）。31 tests（`tests/test_judge_panel.py`）。
 - **031 完工（2026-06-10，雲端 session，merge `ae8cb46`）**：executed 判定純函式（`_backtest_lib.judge_executed` + `parse_roster_snapshot`，mlb_id 優先防同名、歷史不足 → unknown 不給錯 False）+ git 邊界 `fetch_roster_timeline`（baseline = since 前最後 commit）+ row `executed`/`execution` 欄位 + 週報「Executed split」行（hit/miss 進分母即自動有值）。真實歷史 spot-check 三例正確（Rafaela executed / Pederson not-executed / Arraez already-rostered）。測試獨立檔 `tests/test_execution_annotation.py`（26 cases）。詳見 031 issue「實作備註」。


### PR DESCRIPTION
Cloud session work for issue 036 (FA 排序鍵去偏).

- Pure helper `_sort_fa_by_owned`: %owned desc, name-asc tie-break, missing pct last, pct=0 treated as real value
- Replaces vs-P1 sum_diff desc ordering — presentation order no longer encodes the system own verdict (B3 finding)
- 8 unit tests in `tests/test_fa_sort_key.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)