### PR TITLE
feat(039): payload_budget cross-slice line gate (318b enforcement)

### DIFF
--- a/daily-advisor/payload_budget.py
+++ b/daily-advisor/payload_budget.py
@@ -26,17 +26,20 @@ from __future__ import annotations
 
 class PayloadBudgetExceeded(Exception):
     """Raised by ``assert_within`` when a candidate's registered lines exceed
-    the ceiling. Carries the per-slice breakdown so the offending slice is
-    diagnosable from logs / alerts."""
+    the ceiling. Carries the per-slice counts (``slice_counts``) so the
+    offending slice is diagnosable from logs / alerts. Named ``slice_counts``
+    rather than ``breakdown`` on purpose: it is a plain dict attribute, not the
+    ``PayloadBudget.breakdown()`` method — so ``except`` handlers don't reflex
+    into ``e.breakdown()`` and hit a ``'dict' object is not callable``."""
 
-    def __init__(self, candidate, total, limit, breakdown):
+    def __init__(self, candidate, total, limit, slice_counts):
         self.candidate = candidate
         self.total = total
         self.limit = limit
-        self.breakdown = dict(breakdown)
+        self.slice_counts = dict(slice_counts)
         super().__init__(
             f"payload budget exceeded for {candidate!r}: "
-            f"{total} > {limit} lines (breakdown: {self.breakdown})"
+            f"{total} > {limit} lines (breakdown: {self.slice_counts})"
         )
 
 

--- a/daily-advisor/payload_budget.py
+++ b/daily-advisor/payload_budget.py
@@ -1,0 +1,91 @@
+"""Payload line budget — the per-candidate cross-slice accounting gate (039/318b).
+
+Each injection slice declares how many payload lines it adds for one candidate
+via ``register``; the budget enforces a single per-candidate ceiling. It owns
+the *mechanism* (count + assert), never the *policy* (which lines to drop when
+over — that belongs to the injection site, per the PRD: 「ledger 注入片 owns
+既有行讓位規則」). 跨片協作的唯一交會點：各注入片彼此不需認識，只透過同一個
+budget 實例間接協調行數 — 這就是 User story 20 的「單一 enforcement 點」（指
+唯一做超限判定的地方，不是全系統唯一物件）。
+
+Mechanism not policy（設計骨幹）：
+  - budget 只碰「數字」(行數)，永遠不碰行的「內容 / 格式」。
+  - 上限可配置 (``max_lines``)，模組不 hardcode「3 是什麼 / swap 差額表算不算」
+    — 那是注入端 policy。要分池 (tag 池 vs diff 池) 就建多個實例。
+  - per-candidate 實例：每個候選組裝時 new 一個，純記憶體累積，無持久化
+    （仿 DecisionLedger 的 class 形態，但更輕）。
+
+Fail 行為：``assert_within`` 超限 raise ``PayloadBudgetExceeded``（與 AC「超限
+assert」一致）；``within`` / ``remaining`` 為非 raise 查詢，供注入端優雅讓位。
+生產路徑 (fa_scan cron) 應以 try/except 包覆 assert，比照既有 ledger 的
+best-effort 慣例（ledger failure 必須 never abort waiver-log write）。
+"""
+
+from __future__ import annotations
+
+
+class PayloadBudgetExceeded(Exception):
+    """Raised by ``assert_within`` when a candidate's registered lines exceed
+    the ceiling. Carries the per-slice breakdown so the offending slice is
+    diagnosable from logs / alerts."""
+
+    def __init__(self, candidate, total, limit, breakdown):
+        self.candidate = candidate
+        self.total = total
+        self.limit = limit
+        self.breakdown = dict(breakdown)
+        super().__init__(
+            f"payload budget exceeded for {candidate!r}: "
+            f"{total} > {limit} lines (breakdown: {self.breakdown})"
+        )
+
+
+class PayloadBudget:
+    """A per-candidate, per-pool payload line-count gate.
+
+    Inject ``max_lines`` (this pool's ceiling). Each slice calls
+    ``register(slice_id, lines)`` to declare its line contribution for the
+    current candidate; a slice re-registering supersedes its prior value
+    (idempotent — a re-run / re-render never double-counts). Introspect with
+    ``total`` / ``remaining`` / ``within`` (non-raising) or guard the assembled
+    candidate with ``assert_within`` (raises ``PayloadBudgetExceeded``).
+    """
+
+    def __init__(self, max_lines):
+        if max_lines < 0:
+            raise ValueError(f"max_lines must be >= 0, got {max_lines}")
+        self._max = max_lines
+        self._registered: dict[str, int] = {}
+
+    def register(self, slice_id, lines) -> None:
+        """Declare ``slice_id``'s line contribution for the current candidate.
+        Overwrites any prior value for the same slice (idempotent)."""
+        if lines < 0:
+            raise ValueError(
+                f"lines must be >= 0, got {lines} for slice {slice_id!r}")
+        self._registered[slice_id] = lines
+
+    def total(self) -> int:
+        """Sum of all registered slice contributions."""
+        return sum(self._registered.values())
+
+    def remaining(self) -> int:
+        """Lines left before the ceiling; negative when already over (lets the
+        injection site see by how much it must trim)."""
+        return self._max - self.total()
+
+    def within(self) -> bool:
+        """True while total ≤ ceiling (the ceiling itself is allowed)."""
+        return self.total() <= self._max
+
+    def assert_within(self, candidate) -> int:
+        """Guard: raise ``PayloadBudgetExceeded`` if over the ceiling, else
+        return the current total. ``candidate`` is for the diagnostic only."""
+        t = self.total()
+        if t > self._max:
+            raise PayloadBudgetExceeded(candidate, t, self._max, self._registered)
+        return t
+
+    def breakdown(self) -> dict:
+        """A copy of {slice_id: lines} — callers cannot mutate internals."""
+        return dict(self._registered)

--- a/daily-advisor/tests/test_payload_budget.py
+++ b/daily-advisor/tests/test_payload_budget.py
@@ -1,0 +1,150 @@
+"""Unit tests for payload_budget (issue 039 / 318b).
+
+The budget is a pure accounting gate: slices each declare how many payload
+lines they add for one candidate via ``register``, and the budget enforces a
+single per-candidate ceiling. It owns the *mechanism* (count + assert), never
+the *policy* (which lines to drop when over — that is the injection site's
+job). Tests therefore exercise accounting + the assert boundary only, with no
+knowledge of line content or any fa_scan wiring.
+"""
+
+import pytest
+
+from payload_budget import PayloadBudget, PayloadBudgetExceeded
+
+
+# ── construction ──
+
+def test_negative_max_lines_rejected():
+    with pytest.raises(ValueError):
+        PayloadBudget(max_lines=-1)
+
+
+def test_empty_budget_state():
+    b = PayloadBudget(max_lines=3)
+    assert b.total() == 0
+    assert b.remaining() == 3
+    assert b.within() is True
+    assert b.breakdown() == {}
+
+
+# ── register accumulation ──
+
+def test_register_accumulates_across_slices():
+    b = PayloadBudget(max_lines=5)
+    b.register("ledger", 3)
+    b.register("platoon", 1)
+    assert b.total() == 4
+    assert b.remaining() == 1
+    assert b.breakdown() == {"ledger": 3, "platoon": 1}
+
+
+def test_register_same_slice_overwrites_not_doubles():
+    # A slice re-registering (re-run, re-render) must not double-count.
+    b = PayloadBudget(max_lines=5)
+    b.register("ledger", 3)
+    b.register("ledger", 2)  # supersedes, not adds
+    assert b.total() == 2
+    assert b.breakdown() == {"ledger": 2}
+
+
+def test_register_zero_lines_is_legal():
+    # A slice that contributes nothing for this candidate registers 0.
+    b = PayloadBudget(max_lines=3)
+    b.register("platoon", 0)
+    assert b.total() == 0
+    assert b.breakdown() == {"platoon": 0}
+
+
+def test_register_negative_lines_rejected():
+    b = PayloadBudget(max_lines=3)
+    with pytest.raises(ValueError):
+        b.register("platoon", -1)
+
+
+def test_register_returns_none():
+    # register is a side-effecting declaration, not a query — slices use
+    # remaining() to introspect.
+    b = PayloadBudget(max_lines=3)
+    assert b.register("ledger", 1) is None
+
+
+# ── within / boundary ──
+
+def test_within_true_below_and_at_limit():
+    b = PayloadBudget(max_lines=3)
+    b.register("a", 2)
+    assert b.within() is True          # below
+    b.register("b", 1)
+    assert b.total() == 3
+    assert b.within() is True          # exactly at the ceiling is OK (≤)
+    assert b.remaining() == 0
+
+
+def test_within_false_over_limit():
+    b = PayloadBudget(max_lines=3)
+    b.register("a", 4)
+    assert b.within() is False
+    assert b.remaining() == -1         # remaining may go negative
+
+
+# ── assert_within ──
+
+def test_assert_within_returns_total_when_ok():
+    b = PayloadBudget(max_lines=3)
+    b.register("a", 2)
+    assert b.assert_within("Some Candidate") == 2
+
+
+def test_assert_within_passes_exactly_at_limit():
+    b = PayloadBudget(max_lines=3)
+    b.register("a", 3)
+    assert b.assert_within("Some Candidate") == 3  # no raise at the boundary
+
+
+def test_assert_within_raises_when_exceeded():
+    b = PayloadBudget(max_lines=3)
+    b.register("ledger", 3)
+    b.register("swap", 6)
+    with pytest.raises(PayloadBudgetExceeded):
+        b.assert_within("Vargas")
+
+
+def test_exceeded_exception_carries_diagnostic_context():
+    b = PayloadBudget(max_lines=3)
+    b.register("ledger", 3)
+    b.register("swap", 6)
+    with pytest.raises(PayloadBudgetExceeded) as ei:
+        b.assert_within("Vargas")
+    exc = ei.value
+    assert exc.candidate == "Vargas"
+    assert exc.total == 9
+    assert exc.limit == 3
+    assert exc.breakdown == {"ledger": 3, "swap": 6}
+    # the offending slices should be inspectable from the message too
+    assert "Vargas" in str(exc)
+    assert "swap" in str(exc)
+
+
+# ── multi-pool isolation (the "tag pool vs diff pool" use case) ──
+
+def test_multiple_instances_are_independent():
+    # The injection site builds separate pools (e.g. a 3-line tag pool and a
+    # wider diff-table pool) as separate instances; they must not share state.
+    tag_pool = PayloadBudget(max_lines=3)
+    diff_pool = PayloadBudget(max_lines=8)
+    tag_pool.register("platoon", 1)
+    diff_pool.register("swap", 7)
+    assert tag_pool.total() == 1
+    assert diff_pool.total() == 7
+    assert tag_pool.breakdown() == {"platoon": 1}
+    assert diff_pool.breakdown() == {"swap": 7}
+
+
+def test_breakdown_is_a_copy_not_internal_ref():
+    # Callers must not be able to mutate budget internals via breakdown().
+    b = PayloadBudget(max_lines=3)
+    b.register("a", 1)
+    snap = b.breakdown()
+    snap["a"] = 99
+    assert b.breakdown() == {"a": 1}

--- a/daily-advisor/tests/test_payload_budget.py
+++ b/daily-advisor/tests/test_payload_budget.py
@@ -120,7 +120,7 @@ def test_exceeded_exception_carries_diagnostic_context():
     assert exc.candidate == "Vargas"
     assert exc.total == 9
     assert exc.limit == 3
-    assert exc.breakdown == {"ledger": 3, "swap": 6}
+    assert exc.slice_counts == {"ledger": 3, "swap": 6}
     # the offending slices should be inspectable from the message too
     assert "Vargas" in str(exc)
     assert "swap" in str(exc)


### PR DESCRIPTION
Part of #318 (039 ledger 消費端 + payload_budget). Lands the standalone payload-budget enforcement module — the per-candidate line-accounting gate that 318b's payload injection will register against.

## What this is

`payload_budget.py` + 15 unit tests. Mechanism only:
- `register(slice_id, lines)` — each slice declares its line count (idempotent overwrite, accumulates across slices).
- `assert_within(candidate)` — enforces a single configurable ceiling (≤3 new lines/candidate per the PRD), raises `PayloadBudgetExceeded` with a per-slice breakdown.

The line-drop (讓位) policy deliberately stays at the injection site, not here — per the PRD ("ledger 注入片 owns 既有行讓位規則"). The module holds no channel concept: multi-pool (tag pool vs diff pool) is modelled as separate instances, keeping policy out of the mechanism.

## Why now

All 318b consumer modules (044-050 platoon/PA/SP-start/swap/micro-fields) are built and shelved, waiting for payload injection. This is the enforcement point 318b registers against — landing it first so the injection slice has a green gate to wire into.

## Tests

15 cases: construction guard / register accumulation + idempotent overwrite / zero+negative lines / within-boundary (ceiling allowed) / assert_within return + exceed-raise with breakdown / multi-pool isolation / breakdown copy-not-ref.

Full suite green: 1037 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)