### PR TITLE
318b-batter: payload injection — ledger memory + micro-fields + volume-repair chain

### DIFF
--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -2641,10 +2641,10 @@ def _gate_notifications(enrich_map, roster, ledger, today_str):
     """Pure: ACT-NOW notify lines for today's actionable 4★+ verdicts.
 
     Reads each candidate's history from the injected ledger, runs the gate,
-    collects a line per player whose gate says notify. owned_trend is None for
-    now (fast-lane = 5★ only); the %owned-rising fast-lane is plumbed in 318b.
-    Only today's entry counts (the freshness guard skips stale players from a
-    no-op scan)."""
+    collects a line per player whose gate says notify. owned_trend = the
+    candidate's %owned shape (B8, set on the enrichment during payload build)
+    so a fast-rising add fast-lanes past the slow lane. Only today's entry
+    counts (the freshness guard skips stale players from a no-op scan)."""
     msgs = []
     for name, enr in (enrich_map or {}).items():
         hist = ledger.get_history(name)
@@ -2654,8 +2654,9 @@ def _gate_notifications(enrich_map, roster, ledger, today_str):
         if latest.verdict not in ACTIONABLE:
             continue
         stars = enr.stars if enr else None
+        owned_shape = enr.owned_shape if enr else None
         result = gate(hist, latest.verdict, stars or 0,
-                      owned_trend=None, executed=(name in roster))
+                      owned_trend=owned_shape, executed=(name in roster))
         if result.notify:
             msgs.append(f"⚡ {name} — {result.reason}")
     return msgs
@@ -3447,6 +3448,7 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
             f_age = ages.get(str(f.get("mlb_id", "")))
             enr = (enrich_map or {}).get(f.get("name"))
             if enr is not None:
+                enr.owned_shape = (owned or {}).get("shape")  # B8 gate fast-lane
                 fid = f.get("mlb_id")
                 enr.inline_tags.extend(_compute_inline_tags(
                     f, f_age, ped, today_date,
@@ -3466,6 +3468,7 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
             w_age = ages.get(str(w.get("mlb_id", "")))
             enr = (enrich_map or {}).get(w.get("name"))
             if enr is not None:
+                enr.owned_shape = (owned or {}).get("shape")  # B8 gate fast-lane
                 wid = w.get("mlb_id")
                 enr.inline_tags.extend(_compute_inline_tags(
                     w, w_age, ped, today_date,

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -50,6 +50,7 @@ from ledger_enrich import (
 )
 from decision_gate import gate, ACTIONABLE
 from payload_budget import PayloadBudget, PayloadBudgetExceeded
+from prospect_pedigree import post_hype_tag, default_weak_signal, load_pedigree
 
 # Decision ledger (issue 038) — per-player verdict history. apply_waiver_log_block
 # emits (player, verdict) into a sink only at real mutation points, so the
@@ -3139,6 +3140,24 @@ def _inject_318b_lines(name, enrichment, indent="   "):
     return [f"{indent}{line}" for line in out]
 
 
+def _compute_inline_tags(entry, age, ped, today):
+    """Issue-318b inline header tags for one batter candidate (B5 post-hype;
+    B2 platoon + B5 chase-zone land here too). Inline tags ride the header
+    (like add_tags/warn_tags) and do NOT consume the per-candidate line budget.
+    Best-effort — a tag that can't be computed is simply absent, never raises
+    into the scan."""
+    tags = []
+    if ped is not None and today is not None:
+        try:
+            t = post_hype_tag(ped, entry.get("mlb_id"), age,
+                              default_weak_signal(entry.get("score")), today)
+            if t:
+                tags.append(t)
+        except Exception:  # noqa: BLE001 — a tag never blocks the scan
+            pass
+    return tags
+
+
 def _fmt_anchor_block_batter_v4(entry: dict, label: str,
                                  trad_14d: dict | None,
                                  enrichment=None) -> list[str]:
@@ -3240,7 +3259,9 @@ def _fmt_fa_block_batter_v4(entry: dict, idx: int | None,
     pa_tg_str = f"{pa_per_tg:.2f}" if isinstance(pa_per_tg, (int, float)) else "?"
     add_tags = entry.get("add_tags", [])
     warn_tags = entry.get("warn_tags", [])
-    minimal_tags = list(add_tags) + list(warn_tags)
+    # 318b inline tags (post-hype / platoon / chase-zone) ride the header too.
+    inline_tags = list(enrichment.inline_tags) if enrichment else []
+    minimal_tags = list(add_tags) + list(warn_tags) + inline_tags
     tag_str = f" / {' '.join(minimal_tags)}" if minimal_tags else ""
 
     shape_str = ""
@@ -3363,6 +3384,19 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
     trad_14d = _fetch_14d_trad_bulk(trad_subjects)
     # Issue 033 ②: current age for FA + watch prior context (one bulk call)
     ages = _fetch_ages_bulk(list(fa_tagged) + list(watch_tagged))
+    # B5 post-hype: load the prospect pedigree once + resolve today as a date
+    # (best-effort — a missing asset or bad date just means no post-hype tags).
+    ped = None
+    try:
+        ped = load_pedigree()
+    except Exception as e:  # noqa: BLE001
+        print(f"  post-hype: pedigree unavailable ({type(e).__name__})",
+              file=sys.stderr)
+    try:
+        today_date = (datetime.strptime(today_str, "%Y-%m-%d").date()
+                      if today_str else None)
+    except ValueError:
+        today_date = None
 
     # ── 我方候選 drop ──
     lines.append("--- 我方候選 drop（Sum<25 進池，BBE<40 已排除，cant_cut 排除）---")
@@ -3388,9 +3422,13 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
         for idx, f in enumerate(fa_sorted, start=1):
             owned = enrich_owned_trend(f.get("name", ""), fa_history, today_str) \
                 if today_str else None
+            f_age = ages.get(str(f.get("mlb_id", "")))
+            enr = (enrich_map or {}).get(f.get("name"))
+            if enr is not None:
+                enr.inline_tags.extend(
+                    _compute_inline_tags(f, f_age, ped, today_date))
             lines.extend(_fmt_fa_block_batter_v4(
-                f, idx, trad_14d, owned, age=ages.get(str(f.get("mlb_id", ""))),
-                enrichment=(enrich_map or {}).get(f.get("name"))))
+                f, idx, trad_14d, owned, age=f_age, enrichment=enr))
     else:
         lines.append("\n--- FA 打者候選: 無通過品質門檻 ---")
 
@@ -3400,9 +3438,13 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
         for w in watch_tagged:
             owned = enrich_owned_trend(w.get("name", ""), fa_history, today_str) \
                 if today_str else None
+            w_age = ages.get(str(w.get("mlb_id", "")))
+            enr = (enrich_map or {}).get(w.get("name"))
+            if enr is not None:
+                enr.inline_tags.extend(
+                    _compute_inline_tags(w, w_age, ped, today_date))
             lines.extend(_fmt_fa_block_batter_v4(
-                w, None, trad_14d, owned, age=ages.get(str(w.get("mlb_id", ""))),
-                enrichment=(enrich_map or {}).get(w.get("name"))))
+                w, None, trad_14d, owned, age=w_age, enrichment=enr))
 
     # ── %owned 升幅 ──
     group_changes = [

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -49,6 +49,7 @@ from ledger_enrich import (
     SOURCE_SCAN, SOURCE_OWNED_RISER,
 )
 from decision_gate import gate, ACTIONABLE
+from payload_budget import PayloadBudget, PayloadBudgetExceeded
 
 # Decision ledger (issue 038) — per-player verdict history. apply_waiver_log_block
 # emits (player, verdict) into a sink only at real mutation points, so the
@@ -2831,7 +2832,7 @@ def _filter_waiver_log_by_group(section_content, group_type, rostered_names=None
 
 def _build_pass2_data_v2(group_type, urgency_result, low_conf, fa_tagged,
                          watch_tagged, changes, ref_1d, ref_3d, config,
-                         rostered_names=None):
+                         rostered_names=None, enrich_map=None):
     """Build Claude Layer 5 input string: mechanical report + context.
 
     Claude task is to text-ify the pre-computed Sum/urgency/tags/decision and
@@ -2845,6 +2846,7 @@ def _build_pass2_data_v2(group_type, urgency_result, low_conf, fa_tagged,
         return _build_pass2_data_batter_v4(
             urgency_result, low_conf, fa_tagged, watch_tagged,
             changes, ref_1d, ref_3d, config, rostered_names,
+            enrich_map=enrich_map,
         )
 
     lines = []
@@ -3104,13 +3106,50 @@ def _fmt_season_luck_part(sv: dict) -> str | None:
     return f"運氣 {res['gap']:+.3f}{sig}"
 
 
+# ── B1b / 318b: per-candidate payload injection point ──
+
+_PAYLOAD_MAX_LINES_PER_CAND = 3  # PRD User story 20: ≤3 new lines per candidate
+
+
+def _inject_318b_lines(name, enrichment, indent="   "):
+    """Assemble issue-318b injection lines for one candidate under a single
+    per-candidate line budget (User story 20's one enforcement point).
+
+    B1 contributes the ledger note (prev-verdict + add-reason + star). Later
+    slices append their own (slice_id, lines) pools below in priority order —
+    ledger is the churn-protection core and registers first, so if a future
+    slice pushes over budget the lowest-priority pools are the ones that yield.
+    Returns indented payload lines (possibly empty)."""
+    if enrichment is None:
+        return []
+    budget = PayloadBudget(max_lines=_PAYLOAD_MAX_LINES_PER_CAND)
+    # (slice_id, lines) in descending priority. B2-B5 append platoon / PA /
+    # swap / micro pools here.
+    pools = [("ledger", list(enrichment.note_lines or []))]
+    out = []
+    for slice_id, slice_lines in pools:
+        budget.register(slice_id, len(slice_lines))
+        out.extend(slice_lines)
+    try:
+        budget.assert_within(name)
+    except PayloadBudgetExceeded as e:
+        # B1's single pool can't exceed; the eviction policy (drop lowest
+        # priority pools first) is wired when B2+ adds competing pools.
+        print(f"  318b-inject: {e}", file=sys.stderr)
+    return [f"{indent}{line}" for line in out]
+
+
 def _fmt_anchor_block_batter_v4(entry: dict, label: str,
-                                 trad_14d: dict | None) -> list[str]:
+                                 trad_14d: dict | None,
+                                 enrichment=None) -> list[str]:
     """Render one batter (anchor or watch) as raw + percentile + 14d trad.
 
     Positions intentionally omitted — design §1.2 + §3.4 require evaluation
     on hitting data only; surfacing positions risks LLM reasoning like
     "2B is scarce so drop is risky".
+
+    ``enrichment`` (issue 318b): when present, the ledger note is appended as
+    the block's tail (prev-verdict + add-reason + star).
     """
     name = entry.get("name", "?")
     team = entry.get("team", "")
@@ -3167,18 +3206,23 @@ def _fmt_anchor_block_batter_v4(entry: dict, label: str,
         lines.append(f"  Prior 2025: {' / '.join(prior_parts)}")
     else:
         lines.append("  Prior 2025: 無資料")
+    lines.extend(_inject_318b_lines(entry.get("name", "?"), enrichment, "  "))
     return lines
 
 
 def _fmt_fa_block_batter_v4(entry: dict, idx: int | None,
                              trad_14d: dict | None,
                              owned: dict | None,
-                             age: int | None = None) -> list[str]:
+                             age: int | None = None,
+                             enrichment=None) -> list[str]:
     """Render one FA / watch batter as raw + percentile + 14d trad + %owned.
 
     age: current age from _fetch_ages_bulk — rendered on the prior line so
     breakout-vs-fluke priors have the age context (issue 033, 23 歲二年生
     跳級 vs 31 歲 fluke 的先驗完全不同).
+
+    enrichment (issue 318b): when present, the ledger note (prev-verdict +
+    add-reason + star) is appended as the block's tail.
     """
     name = entry.get("name", "?")
     team = entry.get("team", "")
@@ -3256,6 +3300,7 @@ def _fmt_fa_block_batter_v4(entry: dict, idx: int | None,
         lines.append(f"   Prior 2025: {' / '.join(prior_parts)}{age_part}")
     else:
         lines.append(f"   Prior 2025: 無資料 (新人 or 上季 PA 不足){age_part}")
+    lines.extend(_inject_318b_lines(name, enrichment, "   "))
     return lines
 
 
@@ -3282,7 +3327,7 @@ def _sort_fa_by_owned(fa_tagged: list[dict]) -> list[dict]:
 
 def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
                                  watch_tagged, changes, ref_1d, ref_3d, config,
-                                 rostered_names=None):
+                                 rostered_names=None, enrich_map=None):
     """Batter v4 thin Pass-2 input string.
 
     Composition (per docs/batter-framework-upgrade-design.md §1):
@@ -3323,7 +3368,9 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
     lines.append("--- 我方候選 drop（Sum<25 進池，BBE<40 已排除，cant_cut 排除）---")
     if weakest_pool:
         for i, r in enumerate(weakest_pool, start=1):
-            lines.extend(_fmt_anchor_block_batter_v4(r, f"P{i}", trad_14d))
+            lines.extend(_fmt_anchor_block_batter_v4(
+                r, f"P{i}", trad_14d,
+                enrichment=(enrich_map or {}).get(r.get("name"))))
     else:
         lines.append("- 池為空：全隊打者 Sum 皆 ≥25（強），無 drop 候選")
 
@@ -3342,7 +3389,8 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
             owned = enrich_owned_trend(f.get("name", ""), fa_history, today_str) \
                 if today_str else None
             lines.extend(_fmt_fa_block_batter_v4(
-                f, idx, trad_14d, owned, age=ages.get(str(f.get("mlb_id", "")))))
+                f, idx, trad_14d, owned, age=ages.get(str(f.get("mlb_id", ""))),
+                enrichment=(enrich_map or {}).get(f.get("name"))))
     else:
         lines.append("\n--- FA 打者候選: 無通過品質門檻 ---")
 
@@ -3353,7 +3401,8 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
             owned = enrich_owned_trend(w.get("name", ""), fa_history, today_str) \
                 if today_str else None
             lines.extend(_fmt_fa_block_batter_v4(
-                w, None, trad_14d, owned, age=ages.get(str(w.get("mlb_id", "")))))
+                w, None, trad_14d, owned, age=ages.get(str(w.get("mlb_id", ""))),
+                enrichment=(enrich_map or {}).get(w.get("name"))))
 
     # ── %owned 升幅 ──
     group_changes = [
@@ -3493,6 +3542,20 @@ def _process_group(group_type, config, savant_2026, enriched, watch_enriched,
                 entry.update(fa_compute.compute_fa_tags(entry, anchor, group_type))
             watch_tagged.append(entry)
 
+        # Decision-ledger enrichment (issue 039): channel + stars + add_reason
+        # + rendered ledger note per candidate. Computed BEFORE Layer 5 so the
+        # note lines inject into the payload (318b), then reused at the
+        # waiver-log write point (persist channel/stars/add_reason) and the
+        # gate (notify). Best-effort — enrichment never blocks the scan.
+        enrich_map = {}
+        try:
+            enrich_map = build_ledger_enrich_map(
+                fa_tagged + watch_tagged,
+                DecisionLedger(DECISION_LEDGER_PATH), today_str)
+        except Exception as e:  # noqa: BLE001
+            print(f"  ledger-enrich: skipped ({type(e).__name__}: {e})",
+                  file=sys.stderr)
+
         # ── Layer 5: Claude text layer ──
         print(f"  Layer 5 ({label}): Claude 文字化...", file=sys.stderr)
         prompt_path = os.path.join(SCRIPT_DIR, "prompt_fa_scan_pass2_batter.txt")
@@ -3500,7 +3563,7 @@ def _process_group(group_type, config, savant_2026, enriched, watch_enriched,
         data = _build_pass2_data_v2(
             group_type, urgency_result, low_conf, fa_tagged, watch_tagged,
             changes, ref_1d, ref_3d, config,
-            rostered_names=rostered_names,
+            rostered_names=rostered_names, enrich_map=enrich_map,
         )
         advice = _call_claude(prompt_path, data, timeout=900)
 
@@ -3526,16 +3589,8 @@ def _process_group(group_type, config, savant_2026, enriched, watch_enriched,
             position_lookup = _build_position_lookup(
                 group_type, fa_candidates, watch_candidates, config,
             )
-            # Discovery channel + mechanical stars per candidate (issue 039 /
-            # 318a) — persisted onto the ledger at the write point. Best-effort.
-            enrich_map = {}
-            try:
-                enrich_map = build_ledger_enrich_map(
-                    fa_tagged + watch_tagged,
-                    DecisionLedger(DECISION_LEDGER_PATH), today_str)
-            except Exception as e:  # noqa: BLE001 — enrichment never blocks the scan
-                print(f"  ledger-enrich: skipped ({type(e).__name__}: {e})",
-                      file=sys.stderr)
+            # enrich_map computed before Layer 5 (above) — reused here to
+            # persist channel/stars/add_reason onto the recorded verdict.
             _update_waiver_log(advice, today_str, env, position_lookup, enrich_map)
             # Decision gate (issue 041): targeted ACT-NOW push for 4★+ verdicts
             # after the ledger reflects today's records.

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -49,11 +49,12 @@ from ledger_enrich import (
     SOURCE_SCAN, SOURCE_OWNED_RISER,
 )
 from decision_gate import gate, ACTIONABLE
-from payload_budget import PayloadBudget, PayloadBudgetExceeded
+from payload_budget import PayloadBudget
 from prospect_pedigree import post_hype_tag, default_weak_signal, load_pedigree
 from batter_discipline import (
     compute_discipline, discipline_tag, fetch_batter_discipline_bulk)
 from platoon_classifier import classify_platoon, collect_platoon_games
+from pa_projection import project_weekly_pa
 
 # Decision ledger (issue 038) — per-player verdict history. apply_waiver_log_block
 # emits (player, verdict) into a sink only at real mutation points, so the
@@ -3128,19 +3129,22 @@ def _inject_318b_lines(name, enrichment, indent="   "):
     if enrichment is None:
         return []
     budget = PayloadBudget(max_lines=_PAYLOAD_MAX_LINES_PER_CAND)
-    # (slice_id, lines) in descending priority. B2-B5 append platoon / PA /
-    # swap / micro pools here.
+    # (slice_id, lines) in DESCENDING priority — ledger is the churn-protection
+    # core and registers first, so when the budget is tight the lower-priority
+    # PA (B3) / swap (B4) pools are the ones that yield. Inline tags (B2/B5)
+    # ride the header and are NOT budgeted here.
     pools = [("ledger", list(enrichment.note_lines or []))]
+    if enrichment.pa_line:
+        pools.append(("pa", [enrichment.pa_line]))
+    if enrichment.swap_line:
+        pools.append(("swap", [enrichment.swap_line]))
     out = []
     for slice_id, slice_lines in pools:
+        if budget.remaining() < len(slice_lines):
+            budget.register(slice_id, 0)   # yields — would breach the budget
+            continue
         budget.register(slice_id, len(slice_lines))
         out.extend(slice_lines)
-    try:
-        budget.assert_within(name)
-    except PayloadBudgetExceeded as e:
-        # B1's single pool can't exceed; the eviction policy (drop lowest
-        # priority pools first) is wired when B2+ adds competing pools.
-        print(f"  318b-inject: {e}", file=sys.stderr)
     return [f"{indent}{line}" for line in out]
 
 
@@ -3275,6 +3279,51 @@ def _fetch_batter_platoon(mlb_id, team_abbr, end_date, lookback_days=30):
         print(f"  platoon: failed for {mlb_id} ({type(e).__name__}: {e})",
               file=sys.stderr)
         return None
+
+
+# ── B3 / 318b: next-week PA projection (VPS-validated future schedule) ──
+
+_PA_PER_START_EST = 4.3  # league-typical PA for a starting batter in one game
+
+
+def _compute_pa_line(future_games, platoon, pa_per_start=_PA_PER_START_EST):
+    """Next-week PA projection line (issue 045 / B3), or None on insufficient
+    input. A budgeted independent line (not an inline tag): it makes the volume
+    gap explicit before a swap (the Arraez→Pederson −28%-PA lesson)."""
+    if not future_games or not platoon or not pa_per_start:
+        return None
+    proj = project_weekly_pa(future_games, platoon, pa_per_start)
+    if not proj.get("games"):
+        return None
+    return (f"[下週量] 預期 PA {proj['projected_pa']}"
+            f"（{proj['games']} 場 × 先發 {proj['expected_starts']}）")
+
+
+def _fetch_future_games(team_abbr, start_date, ahead_days=7):
+    """Future opponent-handedness games for the PA projection (issue 045 / B3):
+    [{opp_hand: "R"|"L"}] for the team's next ``ahead_days``. Best-effort,
+    VPS-validated (reuses the B2 schedule parse + pitchHand fetch)."""
+    from datetime import date, timedelta
+    try:
+        from stream_sp_scan import ABBR_TO_ID
+        team_id = ABBR_TO_ID.get(team_abbr)
+        if team_id is None:
+            return []
+        start = date.fromisoformat(start_date)
+        end = start + timedelta(days=ahead_days)
+        sched = mlb_api_get(
+            f"/schedule?sportId=1&teamId={team_id}"
+            f"&startDate={start.isoformat()}&endDate={end.isoformat()}"
+            f"&hydrate=probablePitcher")
+        team_games = _parse_team_schedule(sched, team_id)
+        hand_map = _fetch_pitch_hands({tg["opp_starter_id"] for tg in team_games})
+        return [{"opp_hand": hand_map[tg["opp_starter_id"]]}
+                for tg in team_games
+                if hand_map.get(tg["opp_starter_id"]) in ("R", "L")]
+    except Exception as e:  # noqa: BLE001
+        print(f"  pa-proj: future games failed ({type(e).__name__})",
+              file=sys.stderr)
+        return []
 
 
 def _fmt_anchor_block_batter_v4(entry: dict, label: str,
@@ -3562,6 +3611,10 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
                 if f.get("decision") in ("取代", "立即取代"):
                     platoon = _fetch_batter_platoon(
                         fid, f.get("team", ""), today_str)
+                    if platoon:  # B3 PA: future games × this platoon → PA line
+                        enr.pa_line = _compute_pa_line(
+                            _fetch_future_games(f.get("team", ""), today_str),
+                            platoon)
                 enr.inline_tags.extend(_compute_inline_tags(
                     f, f_age, ped, today_date,
                     disc_cur=disc_cur_bulk.get(fid),

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -53,6 +53,7 @@ from payload_budget import PayloadBudget, PayloadBudgetExceeded
 from prospect_pedigree import post_hype_tag, default_weak_signal, load_pedigree
 from batter_discipline import (
     compute_discipline, discipline_tag, fetch_batter_discipline_bulk)
+from platoon_classifier import classify_platoon, collect_platoon_games
 
 # Decision ledger (issue 038) — per-player verdict history. apply_waiver_log_block
 # emits (player, verdict) into a sink only at real mutation points, so the
@@ -3143,15 +3144,17 @@ def _inject_318b_lines(name, enrichment, indent="   "):
     return [f"{indent}{line}" for line in out]
 
 
-def _compute_inline_tags(entry, age, ped, today, disc_cur=None, disc_prior=None):
+def _compute_inline_tags(entry, age, ped, today, disc_cur=None, disc_prior=None,
+                         platoon=None):
     """Issue-318b inline header tags for one batter candidate (B5 post-hype +
-    chase/zone-contact; B2 platoon lands here too). Inline tags ride the header
-    (like add_tags/warn_tags) and do NOT consume the per-candidate line budget.
+    chase/zone-contact, B2 platoon). Inline tags ride the header (like
+    add_tags/warn_tags) and do NOT consume the per-candidate line budget.
     Best-effort — a tag that can't be computed is simply absent, never raises
     into the scan.
 
     disc_cur/disc_prior: this batter's {chase, zone_contact, pa} for the
-    current / prior season (looked up from the bulk Savant join), or None."""
+    current / prior season (looked up from the bulk Savant join), or None.
+    platoon: classify_platoon output dict (label/tag/start-rates), or None."""
     tags = []
     if ped is not None and today is not None:
         try:
@@ -3168,7 +3171,110 @@ def _compute_inline_tags(entry, age, ped, today, disc_cur=None, disc_prior=None)
                 tags.append(t)
         except Exception:  # noqa: BLE001
             pass
+    if platoon and platoon.get("tag"):
+        tags.append(platoon["tag"])
     return tags
+
+
+# ── B2 / 318b: platoon fetch (VPS-validated MLB Stats API; pure parse split out) ──
+
+
+def _parse_team_schedule(sched_json, team_id):
+    """Pure: MLB schedule JSON → [{game_pk, opp_starter_id}] for ``team_id``'s
+    games. Opponent = the side that isn't us; only games whose opponent has a
+    known probable/actual starter are kept (others can't be hand-classified)."""
+    out = []
+    for d in (sched_json or {}).get("dates", []):
+        for g in d.get("games", []):
+            gpk = g.get("gamePk")
+            sides = g.get("teams", {})
+            home, away = sides.get("home", {}), sides.get("away", {})
+            if home.get("team", {}).get("id") == team_id:
+                opp = away
+            elif away.get("team", {}).get("id") == team_id:
+                opp = home
+            else:
+                continue
+            opp_sp = (opp.get("probablePitcher") or {}).get("id")
+            if gpk and opp_sp:
+                out.append({"game_pk": gpk, "opp_starter_id": opp_sp})
+    return out
+
+
+def _fetch_pitch_hands(pids):
+    """Batch pitchHand lookup → {pid: "R"|"L"} (one /people call). Empty on
+    failure. VPS-validated."""
+    ids = [str(p) for p in pids if p]
+    if not ids:
+        return {}
+    try:
+        data = mlb_api_get(f"/people?personIds={','.join(ids)}")
+    except Exception:  # noqa: BLE001
+        return {}
+    out = {}
+    for person in data.get("people", []):
+        code = (person.get("pitchHand") or {}).get("code")
+        if person.get("id") and code in ("R", "L"):
+            out[person["id"]] = code
+    return out
+
+
+def _fetch_batter_started_map(mlb_id, season):
+    """{game_pk: started_bool} from a batter's hitting game log. Empty on
+    failure. VPS-validated."""
+    try:
+        data = mlb_api_get(f"/people/{mlb_id}/stats"
+                           f"?stats=gameLog&season={season}&group=hitting")
+    except Exception:  # noqa: BLE001
+        return {}
+    stats = data.get("stats") or []
+    splits = stats[0].get("splits", []) if stats else []
+    out = {}
+    for s in splits:
+        gpk = (s.get("game") or {}).get("gamePk")
+        if gpk is not None:
+            gs = int((s.get("stat") or {}).get("gamesStarted", 0) or 0)
+            out[gpk] = gs > 0
+    return out
+
+
+def _fetch_batter_platoon(mlb_id, team_abbr, end_date, lookback_days=30):
+    """Best-effort platoon classification for one batter (issue 044 / B2).
+
+    Schedule (team game_pk + opponent probable starter) × the batter's game log
+    (started per game) × opponent starter handedness → classify_platoon.
+    Returns None on any failure or too few classified games (the tag is simply
+    absent). VPS-validated: gated by the本機 Yahoo-touching hook; the MLB Stats
+    API response shapes are confirmed on the VPS."""
+    from datetime import date, timedelta
+    try:
+        from stream_sp_scan import ABBR_TO_ID
+        team_id = ABBR_TO_ID.get(team_abbr)
+        if team_id is None or not mlb_id:
+            return None
+        end = date.fromisoformat(end_date)
+        start = end - timedelta(days=lookback_days)
+        sched = mlb_api_get(
+            f"/schedule?sportId=1&teamId={team_id}"
+            f"&startDate={start.isoformat()}&endDate={end.isoformat()}"
+            f"&hydrate=probablePitcher")
+        team_games = _parse_team_schedule(sched, team_id)
+        if not team_games:
+            return None
+        started_map = _fetch_batter_started_map(mlb_id, end.year)
+        hand_map = _fetch_pitch_hands({tg["opp_starter_id"] for tg in team_games})
+        games, _counts = collect_platoon_games(
+            team_games,
+            get_started=lambda gpk: started_map.get(gpk, False),
+            get_pitch_hand=lambda pid: hand_map.get(pid))
+        games = [g for g in games if g.get("opp_hand") in ("R", "L")]
+        if len(games) < 5:  # too few classified games → no reliable signal
+            return None
+        return classify_platoon(games)
+    except Exception as e:  # noqa: BLE001
+        print(f"  platoon: failed for {mlb_id} ({type(e).__name__}: {e})",
+              file=sys.stderr)
+        return None
 
 
 def _fmt_anchor_block_batter_v4(entry: dict, label: str,
@@ -3450,10 +3556,17 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
             if enr is not None:
                 enr.owned_shape = (owned or {}).get("shape")  # B8 gate fast-lane
                 fid = f.get("mlb_id")
+                # B2 platoon: only for actionable swap candidates — the fetch is
+                # per-candidate (schedule + game log), not paid for every FA.
+                platoon = None
+                if f.get("decision") in ("取代", "立即取代"):
+                    platoon = _fetch_batter_platoon(
+                        fid, f.get("team", ""), today_str)
                 enr.inline_tags.extend(_compute_inline_tags(
                     f, f_age, ped, today_date,
                     disc_cur=disc_cur_bulk.get(fid),
-                    disc_prior=disc_prior_bulk.get(fid)))
+                    disc_prior=disc_prior_bulk.get(fid),
+                    platoon=platoon))
             lines.extend(_fmt_fa_block_batter_v4(
                 f, idx, trad_14d, owned, age=f_age, enrichment=enr))
     else:

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -51,6 +51,8 @@ from ledger_enrich import (
 from decision_gate import gate, ACTIONABLE
 from payload_budget import PayloadBudget, PayloadBudgetExceeded
 from prospect_pedigree import post_hype_tag, default_weak_signal, load_pedigree
+from batter_discipline import (
+    compute_discipline, discipline_tag, fetch_batter_discipline_bulk)
 
 # Decision ledger (issue 038) — per-player verdict history. apply_waiver_log_block
 # emits (player, verdict) into a sink only at real mutation points, so the
@@ -3140,12 +3142,15 @@ def _inject_318b_lines(name, enrichment, indent="   "):
     return [f"{indent}{line}" for line in out]
 
 
-def _compute_inline_tags(entry, age, ped, today):
-    """Issue-318b inline header tags for one batter candidate (B5 post-hype;
-    B2 platoon + B5 chase-zone land here too). Inline tags ride the header
+def _compute_inline_tags(entry, age, ped, today, disc_cur=None, disc_prior=None):
+    """Issue-318b inline header tags for one batter candidate (B5 post-hype +
+    chase/zone-contact; B2 platoon lands here too). Inline tags ride the header
     (like add_tags/warn_tags) and do NOT consume the per-candidate line budget.
     Best-effort — a tag that can't be computed is simply absent, never raises
-    into the scan."""
+    into the scan.
+
+    disc_cur/disc_prior: this batter's {chase, zone_contact, pa} for the
+    current / prior season (looked up from the bulk Savant join), or None."""
     tags = []
     if ped is not None and today is not None:
         try:
@@ -3154,6 +3159,13 @@ def _compute_inline_tags(entry, age, ped, today):
             if t:
                 tags.append(t)
         except Exception:  # noqa: BLE001 — a tag never blocks the scan
+            pass
+    if disc_cur is not None:
+        try:
+            t = discipline_tag(compute_discipline(disc_cur, disc_prior))
+            if t:
+                tags.append(t)
+        except Exception:  # noqa: BLE001
             pass
     return tags
 
@@ -3397,6 +3409,16 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
                       if today_str else None)
     except ValueError:
         today_date = None
+    # B5 chase/zone-contact: two league-bulk Savant CSVs (current + prior year),
+    # joined per batter by mlb_id. Best-effort — a failed fetch just drops the
+    # discipline tag this run (does not block the scan).
+    disc_cur_bulk, disc_prior_bulk = {}, {}
+    try:
+        disc_cur_bulk = fetch_batter_discipline_bulk(2026)
+        disc_prior_bulk = fetch_batter_discipline_bulk(2025)
+    except Exception as e:  # noqa: BLE001
+        print(f"  discipline: bulk fetch failed ({type(e).__name__})",
+              file=sys.stderr)
 
     # ── 我方候選 drop ──
     lines.append("--- 我方候選 drop（Sum<25 進池，BBE<40 已排除，cant_cut 排除）---")
@@ -3425,8 +3447,11 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
             f_age = ages.get(str(f.get("mlb_id", "")))
             enr = (enrich_map or {}).get(f.get("name"))
             if enr is not None:
-                enr.inline_tags.extend(
-                    _compute_inline_tags(f, f_age, ped, today_date))
+                fid = f.get("mlb_id")
+                enr.inline_tags.extend(_compute_inline_tags(
+                    f, f_age, ped, today_date,
+                    disc_cur=disc_cur_bulk.get(fid),
+                    disc_prior=disc_prior_bulk.get(fid)))
             lines.extend(_fmt_fa_block_batter_v4(
                 f, idx, trad_14d, owned, age=f_age, enrichment=enr))
     else:
@@ -3441,8 +3466,11 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
             w_age = ages.get(str(w.get("mlb_id", "")))
             enr = (enrich_map or {}).get(w.get("name"))
             if enr is not None:
-                enr.inline_tags.extend(
-                    _compute_inline_tags(w, w_age, ped, today_date))
+                wid = w.get("mlb_id")
+                enr.inline_tags.extend(_compute_inline_tags(
+                    w, w_age, ped, today_date,
+                    disc_cur=disc_cur_bulk.get(wid),
+                    disc_prior=disc_prior_bulk.get(wid)))
             lines.extend(_fmt_fa_block_batter_v4(
                 w, None, trad_14d, owned, age=w_age, enrichment=enr))
 

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -3115,7 +3115,8 @@ def _fmt_season_luck_part(sv: dict) -> str | None:
 
 # ── B1b / 318b: per-candidate payload injection point ──
 
-_PAYLOAD_MAX_LINES_PER_CAND = 3  # PRD User story 20: ≤3 new lines per candidate
+_PAYLOAD_MAX_LINES_PER_CAND = 3  # base pool: ledger note + PA line (doc Q2)
+_SWAP_POOL_MAX_LINES = 1         # swap pool: own ceiling, never evicted (doc Q3)
 
 
 def _inject_318b_lines(name, enrichment, indent="   "):
@@ -3129,23 +3130,28 @@ def _inject_318b_lines(name, enrichment, indent="   "):
     Returns indented payload lines (possibly empty)."""
     if enrichment is None:
         return []
-    budget = PayloadBudget(max_lines=_PAYLOAD_MAX_LINES_PER_CAND)
-    # (slice_id, lines) in DESCENDING priority — ledger is the churn-protection
-    # core and registers first, so when the budget is tight the lower-priority
-    # PA (B3) / swap (B4) pools are the ones that yield. Inline tags (B2/B5)
-    # ride the header and are NOT budgeted here.
-    pools = [("ledger", list(enrichment.note_lines or []))]
-    if enrichment.pa_line:
-        pools.append(("pa", [enrichment.pa_line]))
-    if enrichment.swap_line:
-        pools.append(("swap", [enrichment.swap_line]))
     out = []
-    for slice_id, slice_lines in pools:
-        if budget.remaining() < len(slice_lines):
-            budget.register(slice_id, 0)   # yields — would breach the budget
+    # Base pool (design doc Q2): ledger memory (highest priority) → PA line.
+    # When tight, the lower-priority PA yields; ledger is the churn-protection
+    # core. Inline tags (B2/B5) ride the header and are NOT budgeted here.
+    base = PayloadBudget(max_lines=_PAYLOAD_MAX_LINES_PER_CAND)
+    base_pools = [("ledger", list(enrichment.note_lines or []))]
+    if enrichment.pa_line:
+        base_pools.append(("pa", [enrichment.pa_line]))
+    for slice_id, slice_lines in base_pools:
+        if base.remaining() < len(slice_lines):
+            base.register(slice_id, 0)    # yields — would breach the base budget
             continue
-        budget.register(slice_id, len(slice_lines))
+        base.register(slice_id, len(slice_lines))
         out.extend(slice_lines)
+    # Swap pool (design doc Q3): a SEPARATE budget instance. 4★+ swap
+    # candidates are rare (~6 in 2.5 months), so the category-exchange line
+    # gets its own ceiling and is NEVER crowded out by the base pool.
+    if enrichment.swap_line:
+        swap = PayloadBudget(max_lines=_SWAP_POOL_MAX_LINES)
+        swap.register("swap", 1)
+        if swap.within():
+            out.append(enrichment.swap_line)
     return [f"{indent}{line}" for line in out]
 
 

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -45,7 +45,7 @@ from decision_ledger import (
     VERDICT_PRECEDENCE,
 )
 from ledger_enrich import (
-    CandidateSignals, compute_candidate_stars,
+    CandidateSignals, enrich_candidate,
     SOURCE_SCAN, SOURCE_OWNED_RISER,
 )
 from decision_gate import gate, ACTIONABLE
@@ -2133,9 +2133,11 @@ def _update_waiver_log_locked(advice, today_str, env=None, position_lookup=None,
         ledger = DecisionLedger(DECISION_LEDGER_PATH)
         emap = enrich_map or {}
         for player, verdict in ledger_records:
-            channel, stars = emap.get(player, (None, None))
+            enr = emap.get(player)
             ledger.record(player, verdict, ts=today_str,
-                          channel=channel, stars=stars)
+                          channel=enr.channel if enr else None,
+                          stars=enr.stars if enr else None,
+                          add_reason=enr.add_reason if enr else None)
         ledger_written = True
     except Exception as e:  # noqa: BLE001 — never break the waiver-log path
         msg = f"[fa_scan] decision-ledger skipped ({type(e).__name__}: {e})"
@@ -2640,13 +2642,14 @@ def _gate_notifications(enrich_map, roster, ledger, today_str):
     Only today's entry counts (the freshness guard skips stale players from a
     no-op scan)."""
     msgs = []
-    for name, (_channel, stars) in (enrich_map or {}).items():
+    for name, enr in (enrich_map or {}).items():
         hist = ledger.get_history(name)
         if not hist or hist[-1].ts != today_str:
             continue
         latest = hist[-1]
         if latest.verdict not in ACTIONABLE:
             continue
+        stars = enr.stars if enr else None
         result = gate(hist, latest.verdict, stars or 0,
                       owned_trend=None, executed=(name in roster))
         if result.notify:
@@ -2668,13 +2671,15 @@ def _notify_gate_actions(enrich_map, config, env, today_str):
               file=sys.stderr)
 
 
-def build_ledger_enrich_map(entries, ledger):
-    """Map name → (channel, stars) for batter candidates (issue 039 / 318a).
+def build_ledger_enrich_map(entries, ledger, today_str):
+    """Map name → CandidateEnrichment for batter candidates (issue 039).
 
-    Channel honours first-contact (via ledger history); stars are today's
-    mechanical rating. The map is threaded to the waiver-log write point,
-    which persists channel/stars onto the recorded verdict. Pure given an
-    injected ledger — unit-tested in test_ledger_enrich_wiring.
+    Each bundle carries channel (first-contact honoured), today's mechanical
+    stars, the never-re-judged add_reason, and the rendered ledger note lines.
+    The map is threaded to (a) the waiver-log write point, which persists
+    channel/stars/add_reason onto the recorded verdict, and (b) the payload
+    builder, which injects note_lines (318b). Pure given an injected ledger —
+    unit-tested in test_ledger_enrich.
     """
     enrich_map = {}
     for entry in entries:
@@ -2682,8 +2687,7 @@ def build_ledger_enrich_map(entries, ledger):
         if not name:
             continue
         sig = _candidate_signals_from_entry(entry)
-        stars, channel, _ = compute_candidate_stars(sig, ledger.get_history(name))
-        enrich_map[name] = (channel, stars)
+        enrich_map[name] = enrich_candidate(sig, ledger.get_history(name), today_str)
     return enrich_map
 
 
@@ -3527,7 +3531,8 @@ def _process_group(group_type, config, savant_2026, enriched, watch_enriched,
             enrich_map = {}
             try:
                 enrich_map = build_ledger_enrich_map(
-                    fa_tagged + watch_tagged, DecisionLedger(DECISION_LEDGER_PATH))
+                    fa_tagged + watch_tagged,
+                    DecisionLedger(DECISION_LEDGER_PATH), today_str)
             except Exception as e:  # noqa: BLE001 — enrichment never blocks the scan
                 print(f"  ledger-enrich: skipped ({type(e).__name__}: {e})",
                       file=sys.stderr)

--- a/daily-advisor/fa_scan.py
+++ b/daily-advisor/fa_scan.py
@@ -54,7 +54,8 @@ from prospect_pedigree import post_hype_tag, default_weak_signal, load_pedigree
 from batter_discipline import (
     compute_discipline, discipline_tag, fetch_batter_discipline_bulk)
 from platoon_classifier import classify_platoon, collect_platoon_games
-from pa_projection import project_weekly_pa
+from pa_projection import project_weekly_pa, project_weekly_categories
+from swap_batter import should_emit_swap, swap_vector_batter, format_swap_line
 
 # Decision ledger (issue 038) — per-player verdict history. apply_waiver_log_block
 # emits (player, verdict) into a sink only at real mutation points, so the
@@ -3326,6 +3327,41 @@ def _fetch_future_games(team_abbr, start_date, ahead_days=7):
         return []
 
 
+# ── B4 / 318b: per-category weekly swap delta (pure; rates injected) ──
+
+
+def _per_pa_rates(trad):
+    """A batter's 14d trad counting → per-PA rates (counting/PA) + ratio
+    passthrough, for the weekly projection. None when PA is too thin to divide
+    (the swap line is then simply absent)."""
+    if not trad:
+        return None
+    pa = trad.get("pa") or 0
+    if pa < 1:
+        return None
+    return {
+        "R": trad.get("r", 0) / pa,
+        "HR": trad.get("hr", 0) / pa,
+        "RBI": trad.get("rbi", 0) / pa,
+        "SB": trad.get("sb", 0) / pa,
+        "BB": trad.get("bb", 0) / pa,
+        "AVG": trad.get("avg", 0),
+        "OPS": trad.get("ops", 0),
+    }
+
+
+def _compute_swap_line(cand_name, cand_rate, cand_pa, inc_name, inc_rate, inc_pa):
+    """Per-category weekly swap delta line (issue 047 / B4): the literal
+    candidate−incumbent exchange in H2H categories, PA column last. None on
+    missing rates. Budgeted line; the 4★+ gate is the caller's (should_emit_swap)."""
+    if not cand_rate or not inc_rate:
+        return None
+    cand_cats = project_weekly_categories(cand_rate, cand_pa)
+    inc_cats = project_weekly_categories(inc_rate, inc_pa)
+    vec = swap_vector_batter(cand_cats, cand_pa, inc_cats, inc_pa)
+    return f"[換算] {format_swap_line(inc_name, cand_name, vec)}"
+
+
 def _fmt_anchor_block_batter_v4(entry: dict, label: str,
                                  trad_14d: dict | None,
                                  enrichment=None) -> list[str]:
@@ -3575,6 +3611,24 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
     except Exception as e:  # noqa: BLE001
         print(f"  discipline: bulk fetch failed ({type(e).__name__})",
               file=sys.stderr)
+    # B4 swap: the incumbent (anchor = our weakest drop candidate) weekly
+    # projection, computed ONCE and reused per actionable swap candidate.
+    # Best-effort — no anchor or a failed fetch just drops swap lines this run.
+    inc_swap_ctx = None
+    if weakest_pool:
+        _anc = weakest_pool[0]
+        _anc_platoon = _fetch_batter_platoon(
+            _anc.get("mlb_id"), _anc.get("team", ""), today_str)
+        if _anc_platoon:
+            _anc_proj = project_weekly_pa(
+                _fetch_future_games(_anc.get("team", ""), today_str),
+                _anc_platoon, _PA_PER_START_EST)
+            _anc_rate = _per_pa_rates(
+                (trad_14d or {}).get(str(_anc.get("mlb_id", ""))))
+            if _anc_rate:
+                inc_swap_ctx = {"name": _anc.get("name", "?"),
+                                "rate": _anc_rate,
+                                "pa": _anc_proj["projected_pa"]}
 
     # ── 我方候選 drop ──
     lines.append("--- 我方候選 drop（Sum<25 進池，BBE<40 已排除，cant_cut 排除）---")
@@ -3611,10 +3665,20 @@ def _build_pass2_data_batter_v4(urgency_result, low_conf, fa_tagged,
                 if f.get("decision") in ("取代", "立即取代"):
                     platoon = _fetch_batter_platoon(
                         fid, f.get("team", ""), today_str)
-                    if platoon:  # B3 PA: future games × this platoon → PA line
-                        enr.pa_line = _compute_pa_line(
-                            _fetch_future_games(f.get("team", ""), today_str),
-                            platoon)
+                    if platoon:
+                        cand_future = _fetch_future_games(
+                            f.get("team", ""), today_str)
+                        enr.pa_line = _compute_pa_line(cand_future, platoon)  # B3
+                        # B4 swap vs incumbent — 4★+ only (the cost-bearing line)
+                        if inc_swap_ctx and should_emit_swap(enr.stars or 0):
+                            cand_proj = project_weekly_pa(
+                                cand_future, platoon, _PA_PER_START_EST)
+                            enr.swap_line = _compute_swap_line(
+                                f.get("name", "?"),
+                                _per_pa_rates((trad_14d or {}).get(str(fid))),
+                                cand_proj["projected_pa"],
+                                inc_swap_ctx["name"], inc_swap_ctx["rate"],
+                                inc_swap_ctx["pa"])
                 enr.inline_tags.extend(_compute_inline_tags(
                     f, f_age, ped, today_date,
                     disc_cur=disc_cur_bulk.get(fid),

--- a/daily-advisor/ledger_enrich.py
+++ b/daily-advisor/ledger_enrich.py
@@ -81,7 +81,8 @@ class CandidateEnrichment:
     channel: str | None = None
     stars: int | None = None
     add_reason: str | None = None
-    note_lines: list = field(default_factory=list)
+    note_lines: list = field(default_factory=list)   # B1: ledger note (budgeted)
+    inline_tags: list = field(default_factory=list)  # B2/B5: header tags (not budgeted)
 
 
 def percentile_of(value, metric) -> int:

--- a/daily-advisor/ledger_enrich.py
+++ b/daily-advisor/ledger_enrich.py
@@ -83,6 +83,7 @@ class CandidateEnrichment:
     add_reason: str | None = None
     note_lines: list = field(default_factory=list)   # B1: ledger note (budgeted)
     inline_tags: list = field(default_factory=list)  # B2/B5: header tags (not budgeted)
+    owned_shape: str | None = None                   # B8: %owned shape → gate fast-lane
 
 
 def percentile_of(value, metric) -> int:

--- a/daily-advisor/ledger_enrich.py
+++ b/daily-advisor/ledger_enrich.py
@@ -84,6 +84,8 @@ class CandidateEnrichment:
     note_lines: list = field(default_factory=list)   # B1: ledger note (budgeted)
     inline_tags: list = field(default_factory=list)  # B2/B5: header tags (not budgeted)
     owned_shape: str | None = None                   # B8: %owned shape → gate fast-lane
+    pa_line: str | None = None                       # B3: next-week PA proj (budgeted)
+    swap_line: str | None = None                     # B4: per-category swap (budgeted)
 
 
 def percentile_of(value, metric) -> int:

--- a/daily-advisor/ledger_enrich.py
+++ b/daily-advisor/ledger_enrich.py
@@ -22,7 +22,8 @@ when trigger evaluation is built.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import date
 
 from daily_advisor import BATTER_PCTILES
 from star_rating import (
@@ -65,6 +66,22 @@ class CandidateSignals:
     prior_barrel_pct: float | None = None
     prior_pa: int | None = None
     pa_tg: float | None = None
+
+
+@dataclass
+class CandidateEnrichment:
+    """The full 318b injection bundle for one candidate — what the payload
+    builder renders and what the ledger persists.
+
+    B1 fills channel / stars / add_reason / note_lines. Later slices
+    (platoon / PA / swap / micro) append their own *trailing-optional* fields
+    here, so enrich_map's value shape stays frozen for consumers: they read
+    ``.stars`` / ``.note_lines`` by name and never unpack a positional tuple
+    whose arity shifts every slice."""
+    channel: str | None = None
+    stars: int | None = None
+    add_reason: str | None = None
+    note_lines: list = field(default_factory=list)
 
 
 def percentile_of(value, metric) -> int:
@@ -119,6 +136,18 @@ def first_channel(history) -> str | None:
     return None
 
 
+def first_add_reason(history) -> str | None:
+    """Earliest recorded add_reason in a player's ledger history — the
+    "why we first picked/watched him" set at first contact, which a later
+    drop suggestion must be confronted with (PRD user story 1/9). Symmetric
+    to first_channel; None if no row carries one (e.g. legacy pre-318b rows)."""
+    for entry in history:
+        ar = getattr(entry, "add_reason", None)
+        if ar is not None:
+            return ar
+    return None
+
+
 def build_star_factors(sig: CandidateSignals, channel: str) -> dict:
     """Assemble the named factor dict star_rating.score consumes (3 pre-trigger
     factors; trigger added by the caller for established players)."""
@@ -151,3 +180,92 @@ def compute_candidate_stars(sig: CandidateSignals, history) -> tuple[int, str, S
         factors["trigger"] = "none"
         result = score(factors, day0=False)
     return result.stars, channel, result
+
+
+# ── B1 / 318b: payload note injection (prev-verdict + add-reason + star) ──
+#
+# These render the ledger context into LLM-payload lines. Every line carries a
+# bracketed `[...]` prefix so the read-back / backtest parser can locate it
+# (the 028/032 grammar already keys on bracketed milestones). The note answers
+# "what did we last decide, and why did we pick him" so a drop suggestion must
+# confront the original add reason instead of reacting to one bad day.
+
+
+def _fmt_xwoba3(v) -> str:
+    """xwOBA convention: 3 decimals, no leading zero (.349 not 0.349)."""
+    s = f"{v:.3f}"
+    return s[1:] if s.startswith("0.") else s
+
+
+def _star_glyphs(stars) -> str:
+    """1-5★ as glyphs; '★?' when the rating is unknown (enrichment failed)."""
+    if not stars or stars < 1:
+        return "★?"
+    return "★" * int(stars)
+
+
+def _days_between(earlier, later) -> int | None:
+    """Whole days between two ISO date strings; None on bad/absent input."""
+    try:
+        return (date.fromisoformat(later) - date.fromisoformat(earlier)).days
+    except (ValueError, TypeError):
+        return None
+
+
+def snapshot_add_reason(sig: CandidateSignals) -> str:
+    """A compact "why we picked him" snapshot from current signals, persisted
+    once at first contact. Mirrors the three core batter metrics; appends the
+    14d xwOBA when a heat spike is what surfaced the pickup. '?' if nothing is
+    known (never empty — the field is the anchor a later drop is confronted
+    with)."""
+    parts = []
+    if sig.xwoba is not None:
+        parts.append(f"xwOBA {_fmt_xwoba3(sig.xwoba)}")
+    if sig.bb_pct is not None:
+        parts.append(f"BB% {sig.bb_pct}")
+    if sig.barrel_pct is not None:
+        parts.append(f"Barrel% {sig.barrel_pct}")
+    if is_hot_14d(sig.xwoba_14d, sig.xwoba):
+        parts.append(f"14d xwOBA {_fmt_xwoba3(sig.xwoba_14d)}")
+    return " / ".join(parts) if parts else "?"
+
+
+def format_ledger_note(history, today_str, stars,
+                       add_reason_fallback=None) -> list[str]:
+    """Render a candidate's ledger context into payload lines.
+
+    day-0 (empty history): one star line (nothing to confront yet — 5★ still
+    needs a validated trigger, but the rating is the payload pre-screen prior).
+    Established: a prev-verdict+age+star line plus the ORIGINAL add reason
+    (first_add_reason, never re-judged), falling back to the live snapshot for
+    legacy rows recorded before add_reason existed.
+    """
+    star_str = _star_glyphs(stars)
+    if not history:
+        return [f"[記事] 新候選 {star_str}"]
+    prev = history[-1]
+    days = _days_between(getattr(prev, "ts", None), today_str)
+    when = f"{days}天前" if days is not None else getattr(prev, "ts", "?")
+    reason = first_add_reason(history) or add_reason_fallback or "?"
+    return [
+        f"[記事] 前判「{getattr(prev, 'verdict', '?')}」{when} {star_str}",
+        f"[原撿因] {reason}",
+    ]
+
+
+def enrich_candidate(sig: CandidateSignals, history, today_str) -> CandidateEnrichment:
+    """Assemble one candidate's full injection bundle.
+
+    Combines the mechanical stars + first-contact channel
+    (``compute_candidate_stars``), the never-re-judged ``add_reason``
+    (the persisted first-contact reason, or a fresh snapshot when none is on
+    record — first contact or a legacy pre-318b row), and the rendered ledger
+    note lines. Pure given ``history`` + ``today_str`` — unit-tested without
+    any fa_scan wiring; the fa_scan layer only extracts ``sig`` from an entry
+    and persists/injects the result."""
+    stars, channel, _ = compute_candidate_stars(sig, history)
+    add_reason = first_add_reason(history) or snapshot_add_reason(sig)
+    note_lines = format_ledger_note(history, today_str, stars,
+                                    add_reason_fallback=add_reason)
+    return CandidateEnrichment(channel=channel, stars=stars,
+                               add_reason=add_reason, note_lines=note_lines)

--- a/daily-advisor/ledger_enrich.py
+++ b/daily-advisor/ledger_enrich.py
@@ -201,13 +201,6 @@ def _fmt_xwoba3(v) -> str:
     return s[1:] if s.startswith("0.") else s
 
 
-def _star_glyphs(stars) -> str:
-    """1-5★ as glyphs; '★?' when the rating is unknown (enrichment failed)."""
-    if not stars or stars < 1:
-        return "★?"
-    return "★" * int(stars)
-
-
 def _days_between(earlier, later) -> int | None:
     """Whole days between two ISO date strings; None on bad/absent input."""
     try:
@@ -234,27 +227,30 @@ def snapshot_add_reason(sig: CandidateSignals) -> str:
     return " / ".join(parts) if parts else "?"
 
 
-def format_ledger_note(history, today_str, stars,
-                       add_reason_fallback=None) -> list[str]:
-    """Render a candidate's ledger context into payload lines.
+def format_ledger_note(history, today_str, add_reason_fallback=None) -> list[str]:
+    """Render a candidate's ledger MEMORY into payload lines.
 
-    day-0 (empty history): one star line (nothing to confront yet — 5★ still
-    needs a validated trigger, but the rating is the payload pre-screen prior).
-    Established: a prev-verdict+age+star line plus the ORIGINAL add reason
-    (first_add_reason, never re-judged), falling back to the live snapshot for
-    legacy rows recorded before add_reason existed.
+    Per design doc Q1, this injects the system's *memory* — what it last
+    decided and why it first picked him — NOT the star rating. The star (1-5★)
+    is a mechanical aggregate; surfacing it to the LLM walks back into the v2
+    "Sum exposed to the LLM" path that batter v4 thin retired. The star stays
+    pre-LLM (payload pre-screen + 041 gate + 051 KPI), never in the payload.
+
+    Empty history = first contact → NO lines (the player has no memory yet;
+    day-0 candidates get a looser budget). Established → two lines: the last
+    verdict + the ORIGINAL add reason (first_add_reason, never re-judged;
+    falls back to the live snapshot for legacy rows predating add_reason).
     """
-    star_str = _star_glyphs(stars)
     if not history:
-        return [f"[記事] 新候選 {star_str}"]
+        return []
     prev = history[-1]
     days = _days_between(getattr(prev, "ts", None), today_str)
-    when = f"{days}天前" if days is not None else getattr(prev, "ts", "?")
-    reason = first_add_reason(history) or add_reason_fallback or "?"
-    return [
-        f"[記事] 前判「{getattr(prev, 'verdict', '?')}」{when} {star_str}",
-        f"[原撿因] {reason}",
-    ]
+    when = f"{days} 天前" if days is not None else getattr(prev, "ts", "?")
+    reason = first_add_reason(history) or add_reason_fallback
+    lines = [f"[記事] 上次 {getattr(prev, 'verdict', '?')}（{when}）"]
+    if reason:
+        lines.append(f"[原撿因] {reason}")
+    return lines
 
 
 def enrich_candidate(sig: CandidateSignals, history, today_str) -> CandidateEnrichment:
@@ -267,9 +263,11 @@ def enrich_candidate(sig: CandidateSignals, history, today_str) -> CandidateEnri
     note lines. Pure given ``history`` + ``today_str`` — unit-tested without
     any fa_scan wiring; the fa_scan layer only extracts ``sig`` from an entry
     and persists/injects the result."""
+    # stars are still computed (041 gate + 051 KPI read them) but NOT injected
+    # into note_lines — design doc Q1 keeps the mechanical aggregate pre-LLM.
     stars, channel, _ = compute_candidate_stars(sig, history)
     add_reason = first_add_reason(history) or snapshot_add_reason(sig)
-    note_lines = format_ledger_note(history, today_str, stars,
+    note_lines = format_ledger_note(history, today_str,
                                     add_reason_fallback=add_reason)
     return CandidateEnrichment(channel=channel, stars=stars,
                                add_reason=add_reason, note_lines=note_lines)

--- a/daily-advisor/tests/test_decision_gate.py
+++ b/daily-advisor/tests/test_decision_gate.py
@@ -24,6 +24,7 @@ from decision_ledger import (
     VERDICT_REPLACE_NOW,
     VERDICT_WATCH,
 )
+from ledger_enrich import CandidateEnrichment
 
 
 def _hist(*rows):
@@ -264,8 +265,8 @@ def test_gate_notifications_pushes_4star_actionable_today():
         "New": [_ent("New", "2026-06-13", VERDICT_REPLACE)],   # day1 pending → no
         "Watched": [_ent("Watched", "2026-06-13", VERDICT_WATCH)],  # not actionable
     }
-    enrich_map = {"Hot": ("structure", 4), "New": ("structure", 4),
-                  "Watched": ("structure", 4)}
+    enrich_map = {n: CandidateEnrichment(channel="structure", stars=4)
+                  for n in ("Hot", "New", "Watched")}
     msgs = _gate_notifications(enrich_map, set(), _FakeLedger(histories), "2026-06-13")
     assert len(msgs) == 1 and msgs[0].startswith("⚡ Hot")
 
@@ -277,7 +278,8 @@ def test_gate_notifications_skips_rostered_and_stale():
                      _ent("Rostered", "2026-06-13", VERDICT_REPLACE)],
         "Stale": [_ent("Stale", "2026-06-10", VERDICT_REPLACE)],  # not today
     }
-    enrich_map = {"Rostered": ("structure", 5), "Stale": ("structure", 5)}
+    enrich_map = {n: CandidateEnrichment(channel="structure", stars=5)
+                  for n in ("Rostered", "Stale")}
     msgs = _gate_notifications(
         enrich_map, {"Rostered"}, _FakeLedger(histories), "2026-06-13")
     assert msgs == []  # rostered=executed (DONE); stale=not today

--- a/daily-advisor/tests/test_decision_gate.py
+++ b/daily-advisor/tests/test_decision_gate.py
@@ -283,3 +283,26 @@ def test_gate_notifications_skips_rostered_and_stale():
     msgs = _gate_notifications(
         enrich_map, {"Rostered"}, _FakeLedger(histories), "2026-06-13")
     assert msgs == []  # rostered=executed (DONE); stale=not today
+
+
+def test_gate_notifications_owned_rising_fast_lanes_day1():
+    # B8: a day-1 4★ replace is PENDING on the slow lane, but a fast-rising
+    # %owned shape fast-lanes it → notify today (the O'Hearn/Horwitz remedy).
+    from fa_scan import _gate_notifications
+    histories = {"Riser": [_ent("Riser", "2026-06-13", VERDICT_REPLACE)]}
+    enrich_map = {"Riser": CandidateEnrichment(channel="market", stars=4,
+                                               owned_shape="rising")}
+    msgs = _gate_notifications(
+        enrich_map, set(), _FakeLedger(histories), "2026-06-13")
+    assert len(msgs) == 1 and msgs[0].startswith("⚡ Riser")
+
+
+def test_gate_notifications_plateau_shape_no_fast_lane_day1():
+    # B8: a non-fast shape leaves the day-1 replace on the slow lane → silent.
+    from fa_scan import _gate_notifications
+    histories = {"Flat": [_ent("Flat", "2026-06-13", VERDICT_REPLACE)]}
+    enrich_map = {"Flat": CandidateEnrichment(channel="structure", stars=4,
+                                              owned_shape="plateau")}
+    msgs = _gate_notifications(
+        enrich_map, set(), _FakeLedger(histories), "2026-06-13")
+    assert msgs == []

--- a/daily-advisor/tests/test_ledger_enrich.py
+++ b/daily-advisor/tests/test_ledger_enrich.py
@@ -12,6 +12,7 @@ import pytest
 
 from decision_ledger import LedgerEntry
 from ledger_enrich import (
+    CandidateEnrichment,
     CandidateSignals,
     CHANNEL_HEAT,
     CHANNEL_MARKET,
@@ -21,10 +22,14 @@ from ledger_enrich import (
     SOURCE_SCAN,
     classify_channel,
     compute_candidate_stars,
+    enrich_candidate,
+    first_add_reason,
     first_channel,
+    format_ledger_note,
     is_hot_14d,
     is_season_strong,
     percentile_of,
+    snapshot_add_reason,
 )
 
 
@@ -172,9 +177,11 @@ def test_build_enrich_map_extracts_entry_and_scores():
                         "barrel_pct": 14.0, "pa": 600},
         "rolling_14d": {"xwoba": 0.355},
     }]
-    emap = build_ledger_enrich_map(entries, _FakeLedger())
-    channel, stars = emap["New Guy"]
-    assert channel == CHANNEL_STRUCTURE and stars == 4
+    emap = build_ledger_enrich_map(entries, _FakeLedger(), "2026-06-18")
+    enr = emap["New Guy"]
+    assert enr.channel == CHANNEL_STRUCTURE and enr.stars == 4
+    assert "xwOBA" in enr.add_reason          # first-contact snapshot persisted
+    assert enr.note_lines and enr.note_lines[0].startswith("[")
 
 
 def test_build_enrich_map_honours_existing_channel():
@@ -188,12 +195,147 @@ def test_build_enrich_map_honours_existing_channel():
                         "barrel_pct": 8.0, "pa": 600},
         "rolling_14d": {"xwoba": 0.360},  # looks hot now
     }]
-    channel, _ = build_ledger_enrich_map(entries, _FakeLedger(hist))["X"]
-    assert channel == "structure"  # never re-judged to heat
+    enr = build_ledger_enrich_map(entries, _FakeLedger(hist), "2026-06-18")["X"]
+    assert enr.channel == "structure"  # never re-judged to heat
 
 
 def test_build_enrich_map_skips_nameless_and_handles_missing_keys():
     from fa_scan import build_ledger_enrich_map
     entries = [{"source": SOURCE_SCAN}, {"name": "Sparse"}]
-    emap = build_ledger_enrich_map(entries, _FakeLedger())
+    emap = build_ledger_enrich_map(entries, _FakeLedger(), "2026-06-18")
     assert "Sparse" in emap and len(emap) == 1  # nameless skipped, sparse ok
+
+
+# ── B1 / 318b: add_reason persistence + ledger note injection ──
+
+def test_snapshot_add_reason_summarizes_season_core():
+    # The first-contact add reason = a compact snapshot of the three core
+    # metrics, so a later drop can be confronted with "why did we pick him".
+    sig = CandidateSignals(source=SOURCE_SCAN, xwoba=0.349,
+                           bb_pct=12.2, barrel_pct=14.0)
+    r = snapshot_add_reason(sig)
+    assert "xwOBA" in r and ".349" in r
+    assert "BB%" in r and "12.2" in r
+    assert "Barrel%" in r and "14.0" in r
+
+
+def test_snapshot_add_reason_includes_heat_when_hot():
+    # a heat-led pickup should record the 14d signal that surfaced it
+    sig = CandidateSignals(source=SOURCE_SCAN, xwoba=0.290, bb_pct=6.0,
+                           barrel_pct=5.0, xwoba_14d=0.360)
+    r = snapshot_add_reason(sig)
+    assert "14d" in r and ".360" in r
+
+
+def test_snapshot_add_reason_missing_metrics_no_crash():
+    # all-None signals must still yield a non-empty, parseable string
+    assert snapshot_add_reason(CandidateSignals(source=SOURCE_SCAN))
+
+
+def test_first_add_reason_returns_earliest_set():
+    hist = [
+        LedgerEntry("X", "watch", "2026-05-09", add_reason=None),
+        LedgerEntry("X", "watch", "2026-05-10", add_reason="xwOBA .349/BB% 12.2"),
+        LedgerEntry("X", "取代", "2026-05-12", add_reason="a newer reason"),
+    ]
+    assert first_add_reason(hist) == "xwOBA .349/BB% 12.2"
+
+
+def test_first_add_reason_none_when_unset():
+    assert first_add_reason([LedgerEntry("X", "watch", "2026-05-09")]) is None
+    assert first_add_reason([]) is None
+
+
+def test_format_ledger_note_day0_single_star_line():
+    # brand-new candidate: no prior verdict to confront, just the star line.
+    lines = format_ledger_note(history=[], today_str="2026-06-18",
+                               stars=4, add_reason_fallback="xwOBA .349")
+    assert len(lines) == 1
+    assert "★★★★" in lines[0]
+    assert "前判" not in lines[0]          # nothing to confront yet
+    assert lines[0].startswith("[")        # machine-parseable prefix
+
+
+def test_format_ledger_note_established_shows_prev_verdict_days_and_reason():
+    hist = [
+        LedgerEntry("X", "watch", "2026-05-13",
+                    add_reason="xwOBA .349/BB% 12.2", stars=3),
+        LedgerEntry("X", "取代", "2026-06-13", add_reason=None, stars=4),
+    ]
+    lines = format_ledger_note(hist, today_str="2026-06-18",
+                               stars=4, add_reason_fallback="now-snapshot")
+    joined = " ".join(lines)
+    assert "取代" in joined                 # latest prior verdict
+    assert "5" in joined                    # 06-13 → 06-18 = 5 days ago
+    assert "xwOBA .349/BB% 12.2" in joined  # ORIGINAL reason (first entry), not fallback
+    assert "now-snapshot" not in joined
+    assert "★★★★" in joined
+
+
+def test_format_ledger_note_falls_back_when_history_lacks_add_reason():
+    # legacy rows recorded before add_reason existed → use the live snapshot.
+    hist = [LedgerEntry("X", "watch", "2026-06-13", add_reason=None, stars=3)]
+    lines = format_ledger_note(hist, today_str="2026-06-18",
+                               stars=3, add_reason_fallback="xwOBA .310/BB% 9")
+    assert "xwOBA .310/BB% 9" in " ".join(lines)
+
+
+def test_format_ledger_note_all_lines_machine_parseable():
+    hist = [LedgerEntry("X", "watch", "2026-06-13",
+                        add_reason="r", stars=3)]
+    lines = format_ledger_note(hist, "2026-06-18", stars=3,
+                               add_reason_fallback="r")
+    assert lines and all(l.startswith("[") for l in lines)
+
+
+def test_format_ledger_note_unknown_stars_renders_safely():
+    # stars=None (enrichment failed) must not crash the note.
+    lines = format_ledger_note(history=[], today_str="2026-06-18",
+                               stars=None, add_reason_fallback="r")
+    assert lines  # still emits something parseable
+
+
+# ── B1a / 318b: enrich_candidate packs the full injection bundle ──
+
+def test_enrich_candidate_day0_packs_channel_stars_reason_note():
+    sig = CandidateSignals(
+        source=SOURCE_SCAN, xwoba=0.349, bb_pct=12.2, barrel_pct=14.0,
+        prior_xwoba=0.349, prior_bb_pct=12.2, prior_barrel_pct=14.0,
+        prior_pa=600, pa_tg=3.9)
+    enr = enrich_candidate(sig, history=[], today_str="2026-06-18")
+    assert isinstance(enr, CandidateEnrichment)
+    assert enr.channel == CHANNEL_STRUCTURE
+    assert enr.stars == 4
+    assert "xwOBA" in enr.add_reason         # snapshot computed at first contact
+    assert enr.note_lines and enr.note_lines[0].startswith("[")
+
+
+def test_enrich_candidate_reuses_persisted_add_reason():
+    # an existing add_reason is the never-re-judged anchor — not recomputed.
+    hist = [LedgerEntry("X", "watch", "2026-05-13", channel="structure",
+                        add_reason="原始 xwOBA .349/BB% 12", stars=3)]
+    sig = CandidateSignals(source=SOURCE_SCAN, xwoba=0.290, bb_pct=6.0,
+                           barrel_pct=5.0, prior_pa=600, pa_tg=3.0)
+    enr = enrich_candidate(sig, history=hist, today_str="2026-06-18")
+    assert enr.add_reason == "原始 xwOBA .349/BB% 12"
+    assert enr.channel == "structure"        # also never re-judged
+    assert "原始 xwOBA .349/BB% 12" in " ".join(enr.note_lines)
+
+
+def test_enrich_candidate_backfills_snapshot_for_legacy_rows():
+    # history exists but predates add_reason → compute a live snapshot so the
+    # note still has an original reason to confront.
+    hist = [LedgerEntry("X", "watch", "2026-06-13", channel="heat",
+                        add_reason=None, stars=2)]
+    sig = CandidateSignals(source=SOURCE_SCAN, xwoba=0.330,
+                           bb_pct=9.0, barrel_pct=10.0)
+    enr = enrich_candidate(sig, history=hist, today_str="2026-06-18")
+    assert enr.add_reason and "xwOBA" in enr.add_reason
+    assert enr.channel == "heat"
+
+
+def test_candidate_enrichment_defaults_are_safe():
+    # an all-default bundle (enrichment failed for a candidate) is inert.
+    enr = CandidateEnrichment()
+    assert enr.channel is None and enr.stars is None
+    assert enr.add_reason is None and enr.note_lines == []

--- a/daily-advisor/tests/test_ledger_enrich.py
+++ b/daily-advisor/tests/test_ledger_enrich.py
@@ -181,7 +181,7 @@ def test_build_enrich_map_extracts_entry_and_scores():
     enr = emap["New Guy"]
     assert enr.channel == CHANNEL_STRUCTURE and enr.stars == 4
     assert "xwOBA" in enr.add_reason          # first-contact snapshot persisted
-    assert enr.note_lines and enr.note_lines[0].startswith("[")
+    assert enr.note_lines == []               # day-0: no memory line (Q1)
 
 
 def test_build_enrich_map_honours_existing_channel():
@@ -246,14 +246,11 @@ def test_first_add_reason_none_when_unset():
     assert first_add_reason([]) is None
 
 
-def test_format_ledger_note_day0_single_star_line():
-    # brand-new candidate: no prior verdict to confront, just the star line.
+def test_format_ledger_note_day0_no_lines():
+    # design doc Q1: first contact has no memory yet → zero injected lines.
     lines = format_ledger_note(history=[], today_str="2026-06-18",
-                               stars=4, add_reason_fallback="xwOBA .349")
-    assert len(lines) == 1
-    assert "★★★★" in lines[0]
-    assert "前判" not in lines[0]          # nothing to confront yet
-    assert lines[0].startswith("[")        # machine-parseable prefix
+                               add_reason_fallback="xwOBA .349")
+    assert lines == []
 
 
 def test_format_ledger_note_established_shows_prev_verdict_days_and_reason():
@@ -263,41 +260,40 @@ def test_format_ledger_note_established_shows_prev_verdict_days_and_reason():
         LedgerEntry("X", "取代", "2026-06-13", add_reason=None, stars=4),
     ]
     lines = format_ledger_note(hist, today_str="2026-06-18",
-                               stars=4, add_reason_fallback="now-snapshot")
+                               add_reason_fallback="now-snapshot")
     joined = " ".join(lines)
     assert "取代" in joined                 # latest prior verdict
     assert "5" in joined                    # 06-13 → 06-18 = 5 days ago
-    assert "xwOBA .349/BB% 12.2" in joined  # ORIGINAL reason (first entry), not fallback
+    assert "xwOBA .349/BB% 12.2" in joined  # ORIGINAL reason (first entry)
     assert "now-snapshot" not in joined
-    assert "★★★★" in joined
+    assert "★" not in joined                # design doc Q1: star is NOT injected
 
 
 def test_format_ledger_note_falls_back_when_history_lacks_add_reason():
     # legacy rows recorded before add_reason existed → use the live snapshot.
     hist = [LedgerEntry("X", "watch", "2026-06-13", add_reason=None, stars=3)]
     lines = format_ledger_note(hist, today_str="2026-06-18",
-                               stars=3, add_reason_fallback="xwOBA .310/BB% 9")
+                               add_reason_fallback="xwOBA .310/BB% 9")
     assert "xwOBA .310/BB% 9" in " ".join(lines)
 
 
 def test_format_ledger_note_all_lines_machine_parseable():
     hist = [LedgerEntry("X", "watch", "2026-06-13",
                         add_reason="r", stars=3)]
-    lines = format_ledger_note(hist, "2026-06-18", stars=3,
-                               add_reason_fallback="r")
+    lines = format_ledger_note(hist, "2026-06-18", add_reason_fallback="r")
     assert lines and all(l.startswith("[") for l in lines)
 
 
-def test_format_ledger_note_unknown_stars_renders_safely():
-    # stars=None (enrichment failed) must not crash the note.
-    lines = format_ledger_note(history=[], today_str="2026-06-18",
-                               stars=None, add_reason_fallback="r")
-    assert lines  # still emits something parseable
+def test_format_ledger_note_no_add_reason_just_prev_line():
+    # established but no add_reason on record and no fallback → only prev line.
+    hist = [LedgerEntry("X", "watch", "2026-06-13", add_reason=None)]
+    lines = format_ledger_note(hist, "2026-06-18")
+    assert len(lines) == 1 and lines[0].startswith("[記事]")
 
 
 # ── B1a / 318b: enrich_candidate packs the full injection bundle ──
 
-def test_enrich_candidate_day0_packs_channel_stars_reason_note():
+def test_enrich_candidate_day0_keeps_stars_reason_but_no_note():
     sig = CandidateSignals(
         source=SOURCE_SCAN, xwoba=0.349, bb_pct=12.2, barrel_pct=14.0,
         prior_xwoba=0.349, prior_bb_pct=12.2, prior_barrel_pct=14.0,
@@ -305,9 +301,9 @@ def test_enrich_candidate_day0_packs_channel_stars_reason_note():
     enr = enrich_candidate(sig, history=[], today_str="2026-06-18")
     assert isinstance(enr, CandidateEnrichment)
     assert enr.channel == CHANNEL_STRUCTURE
-    assert enr.stars == 4
-    assert "xwOBA" in enr.add_reason         # snapshot computed at first contact
-    assert enr.note_lines and enr.note_lines[0].startswith("[")
+    assert enr.stars == 4                     # computed for gate/KPI, not injected
+    assert "xwOBA" in enr.add_reason          # snapshot persisted at first contact
+    assert enr.note_lines == []               # Q1: first contact = no memory line
 
 
 def test_enrich_candidate_reuses_persisted_add_reason():

--- a/daily-advisor/tests/test_payload_injection.py
+++ b/daily-advisor/tests/test_payload_injection.py
@@ -219,3 +219,74 @@ def test_inline_tags_combines_post_hype_and_discipline():
                                 disc_cur=cur, disc_prior=prior)
     assert any("post-hype" in t for t in tags)
     assert any("選球進化" in t for t in tags)
+
+
+# ── B2 / 318b: platoon-share inline tag ──
+
+def test_inline_tags_strong_side_platoon_warns():
+    # the Arraez→Pederson -28% weekly-PA blind spot: a strong-side platoon bat
+    # gets the warning so a quality-only swap doesn't silently lose PA.
+    entry = _fa_entry(mlb_id=123456, score=26)
+    platoon = {"label": "strong_side", "tag": "⚠️ 強側平台 (vs RHP)",
+               "start_rate_vs_r": 0.9, "start_rate_vs_l": 0.1,
+               "overall_start_rate": 0.55}
+    tags = _compute_inline_tags(entry, 28, None, _dt.date(2026, 6, 18),
+                                platoon=platoon)
+    assert any("強側平台" in t for t in tags)
+
+
+def test_inline_tags_everyday_platoon_no_warn():
+    entry = _fa_entry(mlb_id=123456, score=26)
+    platoon = {"label": "everyday", "tag": None, "start_rate_vs_r": 0.95,
+               "start_rate_vs_l": 0.92, "overall_start_rate": 0.94}
+    tags = _compute_inline_tags(entry, 28, None, _dt.date(2026, 6, 18),
+                                platoon=platoon)
+    assert not any("平台" in t for t in tags)
+
+
+def test_inline_tags_no_platoon_no_tag():
+    entry = _fa_entry(mlb_id=123456, score=26)
+    tags = _compute_inline_tags(entry, 28, None, _dt.date(2026, 6, 18))
+    assert not any("平台" in t or "替補" in t for t in tags)
+
+
+# ── B2 / 318b: team schedule parse (pure; the fetch path is VPS-validated) ──
+
+def test_parse_team_schedule_picks_opponent_starter_by_side():
+    from fa_scan import _parse_team_schedule
+    sched = {"dates": [{"games": [{
+        "gamePk": 1,
+        "teams": {
+            "home": {"team": {"id": 10}, "probablePitcher": {"id": 100}},
+            "away": {"team": {"id": 20}, "probablePitcher": {"id": 200}},
+        }}]}]}
+    # our team home → opponent is away (starter 200); our team away → starter 100
+    assert _parse_team_schedule(sched, 10) == [{"game_pk": 1, "opp_starter_id": 200}]
+    assert _parse_team_schedule(sched, 20) == [{"game_pk": 1, "opp_starter_id": 100}]
+
+
+def test_parse_team_schedule_skips_missing_probable():
+    from fa_scan import _parse_team_schedule
+    sched = {"dates": [{"games": [{
+        "gamePk": 1,
+        "teams": {"home": {"team": {"id": 10}}, "away": {"team": {"id": 20}}},
+    }]}]}
+    assert _parse_team_schedule(sched, 10) == []  # no opponent starter → skip
+
+
+def test_parse_team_schedule_skips_unrelated_game():
+    from fa_scan import _parse_team_schedule
+    sched = {"dates": [{"games": [{
+        "gamePk": 1,
+        "teams": {
+            "home": {"team": {"id": 30}, "probablePitcher": {"id": 100}},
+            "away": {"team": {"id": 40}, "probablePitcher": {"id": 200}},
+        }}]}]}
+    assert _parse_team_schedule(sched, 10) == []  # our team not in this game
+
+
+def test_parse_team_schedule_empty_inputs():
+    from fa_scan import _parse_team_schedule
+    assert _parse_team_schedule(None, 10) == []
+    assert _parse_team_schedule({}, 10) == []
+    assert _parse_team_schedule({"dates": []}, 10) == []

--- a/daily-advisor/tests/test_payload_injection.py
+++ b/daily-advisor/tests/test_payload_injection.py
@@ -114,3 +114,68 @@ def test_anchor_block_default_unchanged():
                                            enrichment=None)
     assert plain == explicit
     assert not any("[記事]" in l for l in plain)
+
+
+# ── B5 / 318b: post-hype inline tag ──
+
+import datetime as _dt
+
+from fa_scan import _compute_inline_tags
+
+
+def _ped(mlb_id=123456, rank=5, year=2024, updated="2026-03-01"):
+    from prospect_pedigree import parse_pedigree
+    return parse_pedigree({
+        "meta": {"updated": updated, "stale_after_month": 3},
+        "prospects": {str(mlb_id): {"best_rank": rank, "best_rank_year": year,
+                                    "name": "Test FA"}},
+    })
+
+
+def test_inline_tags_post_hype_fires_young_weak_pedigreed():
+    # top-5 prospect, age 23, weak season Sum → discount tag fires
+    entry = _fa_entry(mlb_id=123456, score=12)
+    tags = _compute_inline_tags(entry, age=23, ped=_ped(),
+                                today=_dt.date(2026, 6, 18))
+    assert any("post-hype 新秀" in t and "#5" in t for t in tags)
+
+
+def test_inline_tags_not_young_no_fire():
+    entry = _fa_entry(mlb_id=123456, score=12)
+    tags = _compute_inline_tags(entry, age=30, ped=_ped(),
+                                today=_dt.date(2026, 6, 18))
+    assert not any("post-hype" in t for t in tags)
+
+
+def test_inline_tags_strong_sum_no_fire():
+    # good Sum = results not weak → no discount needed
+    entry = _fa_entry(mlb_id=123456, score=26)
+    tags = _compute_inline_tags(entry, age=23, ped=_ped(),
+                                today=_dt.date(2026, 6, 18))
+    assert not any("post-hype" in t for t in tags)
+
+
+def test_inline_tags_stale_list_marks_overdue():
+    # list 2 years behind → stale wording, never silently trusted
+    entry = _fa_entry(mlb_id=123456, score=12)
+    tags = _compute_inline_tags(entry, age=23, ped=_ped(updated="2024-03-01"),
+                                today=_dt.date(2026, 6, 18))
+    assert any("post-hype 名單過期" in t for t in tags)
+
+
+def test_inline_tags_no_ped_empty():
+    assert _compute_inline_tags(_fa_entry(), 23, None,
+                                _dt.date(2026, 6, 18)) == []
+
+
+def test_fa_block_header_shows_inline_tags():
+    enr = CandidateEnrichment(stars=3,
+                              inline_tags=["✅ post-hype 新秀 (#5 2024)"])
+    lines = _fmt_fa_block_batter_v4(_fa_entry(), 1, None, None,
+                                    age=23, enrichment=enr)
+    assert "post-hype 新秀" in lines[0]  # appears in the header line
+
+
+def test_fa_block_header_no_inline_tags_when_absent():
+    lines = _fmt_fa_block_batter_v4(_fa_entry(), 1, None, None, age=23)
+    assert "post-hype" not in lines[0]

--- a/daily-advisor/tests/test_payload_injection.py
+++ b/daily-advisor/tests/test_payload_injection.py
@@ -290,3 +290,50 @@ def test_parse_team_schedule_empty_inputs():
     assert _parse_team_schedule(None, 10) == []
     assert _parse_team_schedule({}, 10) == []
     assert _parse_team_schedule({"dates": []}, 10) == []
+
+
+# ── B3 / 318b: PA projection line + per-candidate budget eviction ──
+
+def test_inject_evicts_lowest_priority_over_budget():
+    # ledger 2 + pa 1 = 3 (full); swap is lowest priority → yields.
+    enr = CandidateEnrichment(note_lines=["[記事] a", "[原撿因] b"],
+                              pa_line="[下週量] c", swap_line="[換算] d")
+    out = _inject_318b_lines("X", enr, "")
+    assert out == ["[記事] a", "[原撿因] b", "[下週量] c"]
+    assert "[換算] d" not in out  # swap evicted (lowest priority)
+
+
+def test_inject_keeps_pa_and_swap_when_ledger_one_line():
+    # day-0 ledger = 1 line → pa + swap both fit (1+1+1 = 3).
+    enr = CandidateEnrichment(note_lines=["[記事] new"],
+                              pa_line="[下週量] pa", swap_line="[換算] sw")
+    out = _inject_318b_lines("X", enr, "")
+    assert out == ["[記事] new", "[下週量] pa", "[換算] sw"]
+
+
+def test_compute_pa_line_projects_weekly_pa():
+    from fa_scan import _compute_pa_line
+    future = [{"opp_hand": "R"}] * 4 + [{"opp_hand": "L"}] * 2
+    platoon = {"start_rate_vs_r": 0.95, "start_rate_vs_l": 0.92,
+               "overall_start_rate": 0.94}
+    line = _compute_pa_line(future, platoon)
+    assert line.startswith("[下週量]") and "PA" in line and "6 場" in line
+
+
+def test_compute_pa_line_strong_side_projects_fewer_pa():
+    # the volume blind spot, made visible: a strong-side bat facing mostly LHP
+    # projects fewer PA than an everyday bat over the same schedule.
+    from pa_projection import project_weekly_pa
+    future = [{"opp_hand": "L"}] * 5 + [{"opp_hand": "R"}]
+    strong = {"start_rate_vs_r": 0.9, "start_rate_vs_l": 0.1,
+              "overall_start_rate": 0.5}
+    everyday = {"start_rate_vs_r": 0.95, "start_rate_vs_l": 0.92,
+                "overall_start_rate": 0.94}
+    assert (project_weekly_pa(future, strong, 4.3)["projected_pa"]
+            < project_weekly_pa(future, everyday, 4.3)["projected_pa"])
+
+
+def test_compute_pa_line_none_on_insufficient_input():
+    from fa_scan import _compute_pa_line
+    assert _compute_pa_line([], {"overall_start_rate": 0.9}) is None
+    assert _compute_pa_line([{"opp_hand": "R"}], None) is None

--- a/daily-advisor/tests/test_payload_injection.py
+++ b/daily-advisor/tests/test_payload_injection.py
@@ -1,0 +1,116 @@
+"""Unit tests for issue 039 / 318b (B1b) — LLM payload injection of the ledger
+note (prev-verdict + add-reason + star) under a per-candidate line budget.
+
+The note answers "what did we last decide, and why did we pick him" so a drop
+suggestion confronts the original add reason instead of one bad day.
+``_inject_318b_lines`` is the single injection point later slices
+(platoon/PA/swap/micro) register their pools into; the ``_fmt_*_batter_v4``
+blocks call it before returning. Pure given a CandidateEnrichment — no Yahoo /
+ledger IO.
+"""
+
+from fa_scan import (
+    _fmt_anchor_block_batter_v4,
+    _fmt_fa_block_batter_v4,
+    _inject_318b_lines,
+)
+from ledger_enrich import CandidateEnrichment
+
+
+def _fa_entry(**ov):
+    e = {
+        "name": "Test FA", "mlb_id": 123456, "team": "HOU", "pct": 12,
+        "status": "",
+        "savant_2026": {"xwoba": 0.320, "bb_pct": 8.0, "barrel_pct": 9.0,
+                        "hh_pct": 42.0, "bbe": 60},
+        "prior_stats": {"xwoba": 0.310, "bb_pct": 7.5, "barrel_pct": 8.0,
+                        "pa": 520},
+        "derived": {"pa_per_tg": 3.8}, "rolling_14d": {},
+        "add_tags": [], "warn_tags": [],
+    }
+    e.update(ov)
+    return e
+
+
+def _anchor_entry(**ov):
+    e = {
+        "name": "My Guy", "mlb_id": 654321, "team": "NYY",
+        "savant_2026": {"xwoba": 0.300, "bb_pct": 7.0, "barrel_pct": 7.0,
+                        "hh_pct": 40.0, "bbe": 80},
+        "prior_stats": {"xwoba": 0.305, "bb_pct": 7.2, "barrel_pct": 7.5,
+                        "pa": 600},
+        "derived": {"pa_per_tg": 3.5}, "rolling_14d": {},
+        "mlb_2026": {"plateAppearances": 250},
+    }
+    e.update(ov)
+    return e
+
+
+# ── _inject_318b_lines (pure) ──
+
+def test_inject_none_enrichment_empty():
+    assert _inject_318b_lines("X", None, "   ") == []
+
+
+def test_inject_empty_notes_empty():
+    # enrichment present but no notes (enrich produced nothing) → no lines
+    assert _inject_318b_lines("X", CandidateEnrichment(stars=3), "   ") == []
+
+
+def test_inject_renders_notes_with_indent():
+    enr = CandidateEnrichment(stars=4, note_lines=[
+        "[記事] 前判「取代」5天前 ★★★★", "[原撿因] xwOBA .349/BB% 12"])
+    out = _inject_318b_lines("X", enr, "   ")
+    assert out == ["   [記事] 前判「取代」5天前 ★★★★",
+                   "   [原撿因] xwOBA .349/BB% 12"]
+
+
+def test_inject_day0_single_line_respects_other_indent():
+    enr = CandidateEnrichment(stars=4, note_lines=["[記事] 新候選 ★★★★"])
+    assert _inject_318b_lines("X", enr, "  ") == ["  [記事] 新候選 ★★★★"]
+
+
+def test_inject_within_three_line_budget_does_not_drop():
+    # ledger alone is ≤2 lines — comfortably under the ≤3 per-candidate ceiling.
+    enr = CandidateEnrichment(stars=5, note_lines=["a", "b"])
+    out = _inject_318b_lines("X", enr, "")
+    assert out == ["a", "b"]
+
+
+# ── _fmt_fa_block_batter_v4 wiring (FA + watch) ──
+
+def test_fa_block_appends_note_when_enrichment_given():
+    enr = CandidateEnrichment(stars=4,
+                              note_lines=["[記事] 前判「取代」5天前 ★★★★"])
+    lines = _fmt_fa_block_batter_v4(_fa_entry(), 1, None, None,
+                                    age=28, enrichment=enr)
+    assert any("[記事] 前判「取代」" in l for l in lines)
+    # injected after the existing prior line — note is the block's tail
+    assert "[記事]" in lines[-1]
+
+
+def test_fa_block_default_no_enrichment_unchanged():
+    # backward-compatible: omitting enrichment renders exactly as before.
+    plain = _fmt_fa_block_batter_v4(_fa_entry(), 1, None, None, age=28)
+    explicit = _fmt_fa_block_batter_v4(_fa_entry(), 1, None, None,
+                                       age=28, enrichment=None)
+    assert plain == explicit
+    assert not any("[記事]" in l for l in plain)
+
+
+# ── _fmt_anchor_block_batter_v4 wiring (my-team drop pool) ──
+
+def test_anchor_block_appends_note():
+    enr = CandidateEnrichment(stars=3,
+                              note_lines=["[記事] 前判「觀察」3天前 ★★★"])
+    lines = _fmt_anchor_block_batter_v4(_anchor_entry(), "P1", None,
+                                        enrichment=enr)
+    assert any("[記事] 前判「觀察」" in l for l in lines)
+
+
+def test_anchor_block_default_unchanged():
+    plain = _fmt_anchor_block_batter_v4(_anchor_entry(), "P1", None)
+    explicit = _fmt_anchor_block_batter_v4(_anchor_entry(), "P1", None,
+                                           enrichment=None)
+    assert plain == explicit
+    assert not any("[記事]" in l for l in plain)

--- a/daily-advisor/tests/test_payload_injection.py
+++ b/daily-advisor/tests/test_payload_injection.py
@@ -58,21 +58,21 @@ def test_inject_empty_notes_empty():
 
 
 def test_inject_renders_notes_with_indent():
-    enr = CandidateEnrichment(stars=4, note_lines=[
-        "[記事] 前判「取代」5天前 ★★★★", "[原撿因] xwOBA .349/BB% 12"])
+    enr = CandidateEnrichment(note_lines=[
+        "[記事] 上次 取代（5 天前）", "[原撿因] xwOBA .349/BB% 12"])
     out = _inject_318b_lines("X", enr, "   ")
-    assert out == ["   [記事] 前判「取代」5天前 ★★★★",
+    assert out == ["   [記事] 上次 取代（5 天前）",
                    "   [原撿因] xwOBA .349/BB% 12"]
 
 
-def test_inject_day0_single_line_respects_other_indent():
-    enr = CandidateEnrichment(stars=4, note_lines=["[記事] 新候選 ★★★★"])
-    assert _inject_318b_lines("X", enr, "  ") == ["  [記事] 新候選 ★★★★"]
+def test_inject_single_note_line_respects_other_indent():
+    enr = CandidateEnrichment(note_lines=["[記事] 上次 觀察（3 天前）"])
+    assert _inject_318b_lines("X", enr, "  ") == ["  [記事] 上次 觀察（3 天前）"]
 
 
 def test_inject_within_three_line_budget_does_not_drop():
     # ledger alone is ≤2 lines — comfortably under the ≤3 per-candidate ceiling.
-    enr = CandidateEnrichment(stars=5, note_lines=["a", "b"])
+    enr = CandidateEnrichment(note_lines=["a", "b"])
     out = _inject_318b_lines("X", enr, "")
     assert out == ["a", "b"]
 
@@ -80,11 +80,10 @@ def test_inject_within_three_line_budget_does_not_drop():
 # ── _fmt_fa_block_batter_v4 wiring (FA + watch) ──
 
 def test_fa_block_appends_note_when_enrichment_given():
-    enr = CandidateEnrichment(stars=4,
-                              note_lines=["[記事] 前判「取代」5天前 ★★★★"])
+    enr = CandidateEnrichment(note_lines=["[記事] 上次 取代（5 天前）"])
     lines = _fmt_fa_block_batter_v4(_fa_entry(), 1, None, None,
                                     age=28, enrichment=enr)
-    assert any("[記事] 前判「取代」" in l for l in lines)
+    assert any("[記事] 上次 取代" in l for l in lines)
     # injected after the existing prior line — note is the block's tail
     assert "[記事]" in lines[-1]
 
@@ -101,11 +100,10 @@ def test_fa_block_default_no_enrichment_unchanged():
 # ── _fmt_anchor_block_batter_v4 wiring (my-team drop pool) ──
 
 def test_anchor_block_appends_note():
-    enr = CandidateEnrichment(stars=3,
-                              note_lines=["[記事] 前判「觀察」3天前 ★★★"])
+    enr = CandidateEnrichment(note_lines=["[記事] 上次 觀察（3 天前）"])
     lines = _fmt_anchor_block_batter_v4(_anchor_entry(), "P1", None,
                                         enrichment=enr)
-    assert any("[記事] 前判「觀察」" in l for l in lines)
+    assert any("[記事] 上次 觀察" in l for l in lines)
 
 
 def test_anchor_block_default_unchanged():
@@ -294,17 +292,28 @@ def test_parse_team_schedule_empty_inputs():
 
 # ── B3 / 318b: PA projection line + per-candidate budget eviction ──
 
-def test_inject_evicts_lowest_priority_over_budget():
-    # ledger 2 + pa 1 = 3 (full); swap is lowest priority → yields.
+def test_inject_swap_pool_independent_not_evicted_by_base():
+    # base full (ledger 2 + PA 1 = 3) but swap is in its OWN pool → still out
+    # (design doc Q3: the rare 4★+ exchange line is never crowded out).
     enr = CandidateEnrichment(note_lines=["[記事] a", "[原撿因] b"],
                               pa_line="[下週量] c", swap_line="[換算] d")
     out = _inject_318b_lines("X", enr, "")
-    assert out == ["[記事] a", "[原撿因] b", "[下週量] c"]
-    assert "[換算] d" not in out  # swap evicted (lowest priority)
+    assert out == ["[記事] a", "[原撿因] b", "[下週量] c", "[換算] d"]
+
+
+def test_inject_base_pool_evicts_pa_when_ledger_fills_it():
+    # contrived 3-line ledger fills the base budget → PA yields; swap stays
+    # (independent pool, design doc Q3).
+    enr = CandidateEnrichment(note_lines=["l1", "l2", "l3"],
+                              pa_line="[下週量] pa", swap_line="[換算] sw")
+    out = _inject_318b_lines("X", enr, "")
+    assert out[:3] == ["l1", "l2", "l3"]   # base full with ledger
+    assert "[下週量] pa" not in out         # PA yields to the base ceiling
+    assert "[換算] sw" in out               # swap independent → still out
 
 
 def test_inject_keeps_pa_and_swap_when_ledger_one_line():
-    # day-0 ledger = 1 line → pa + swap both fit (1+1+1 = 3).
+    # ledger 1 + PA 1 in base (≤3) + swap in its own pool → all three appear.
     enr = CandidateEnrichment(note_lines=["[記事] new"],
                               pa_line="[下週量] pa", swap_line="[換算] sw")
     out = _inject_318b_lines("X", enr, "")

--- a/daily-advisor/tests/test_payload_injection.py
+++ b/daily-advisor/tests/test_payload_injection.py
@@ -179,3 +179,43 @@ def test_fa_block_header_shows_inline_tags():
 def test_fa_block_header_no_inline_tags_when_absent():
     lines = _fmt_fa_block_batter_v4(_fa_entry(), 1, None, None, age=23)
     assert "post-hype" not in lines[0]
+
+
+# ── B5 / 318b: chase / zone-contact YoY discipline inline tag ──
+
+def test_inline_tags_chase_zone_improvement_fires():
+    # chase -6.0 (sig) + zone-contact +5.0 (sig) → discipline-improving tag
+    entry = _fa_entry(mlb_id=123456, score=26)  # strong Sum → no post-hype
+    cur = {"chase": 24.0, "zone_contact": 88.0, "pa": 300}
+    prior = {"chase": 30.0, "zone_contact": 83.0, "pa": 400}
+    tags = _compute_inline_tags(entry, age=28, ped=None,
+                                today=_dt.date(2026, 6, 18),
+                                disc_cur=cur, disc_prior=prior)
+    assert any("選球進化" in t and "chase -6.0" in t for t in tags)
+
+
+def test_inline_tags_discipline_absent_without_data():
+    entry = _fa_entry(mlb_id=123456, score=26)
+    tags = _compute_inline_tags(entry, 28, None, _dt.date(2026, 6, 18))
+    assert not any("選球" in t or "擊球接觸" in t for t in tags)
+
+
+def test_inline_tags_thin_current_sample_no_discipline():
+    # cur PA below CUR_PA_FLOOR (40) → compute_discipline returns None → no tag
+    entry = _fa_entry(mlb_id=123456, score=26)
+    cur = {"chase": 24.0, "zone_contact": 88.0, "pa": 20}
+    prior = {"chase": 30.0, "zone_contact": 83.0, "pa": 400}
+    tags = _compute_inline_tags(entry, 28, None, _dt.date(2026, 6, 18),
+                                disc_cur=cur, disc_prior=prior)
+    assert not any("選球" in t for t in tags)
+
+
+def test_inline_tags_combines_post_hype_and_discipline():
+    # a young weak post-hype prospect who is ALSO improving discipline → both
+    entry = _fa_entry(mlb_id=123456, score=12)
+    cur = {"chase": 24.0, "zone_contact": 88.0, "pa": 300}
+    prior = {"chase": 30.0, "zone_contact": 83.0, "pa": 400}
+    tags = _compute_inline_tags(entry, 23, _ped(), _dt.date(2026, 6, 18),
+                                disc_cur=cur, disc_prior=prior)
+    assert any("post-hype" in t for t in tags)
+    assert any("選球進化" in t for t in tags)


### PR DESCRIPTION
## What

第一批 318b payload 注入（**batter 端**）：把 #316 量修復鏈 + micro-fields 模組（044-050）+ ledger 記憶（038-041）接進實際送 LLM 的 batter payload。依 `docs/318b-injection-design.md`（2026-06-15 六題定稿）分兩批的第一批。

## Slices（9 commit）

- **B1a/B1b** — `CandidateEnrichment` dataclass + add_reason 持久化 + ledger note 注入（prev-verdict + 原撿因）+ `payload_budget` 串接 + enrich 前移
- **B5 / B5b** — post-hype 新秀 tag + chase/zone-contact YoY tag（inline，不佔行）
- **B8** — %owned shape → gate 快軌（closes 318a gate caveat）
- **B2 / B3 / B4** — platoon 陷阱 tag → 下週 PA 投影行 → 逐類別 swap 差額行（量修復鏈；4★+ swap 走獨立 pool）
- **Q1/Q3 fix** — 對齊 design doc：star 不注入（batter v4 thin）、day0 零行、swap 獨立 budget pool

## Design doc 對齊

`docs/318b-injection-design.md` 六決策落實：Q1（star 不注入、ledger 只 prev-verdict + add-reason）、Q2（tag 擠既有行算 0）、Q3（swap 獨立 pool）、Q6（backfill tagged add_reason — 留第二批）。

## 測試

1086 tests green（本機 TDD）。純函式邏輯（note 格式、budget 讓位/獨立 pool、inline tags、PA/swap 投影、schedule parse、per-PA rate）全本機驗。

## ⚠️ VPS-validated only

`fa_scan.py` 是 Yahoo-touching（本機 hook 擋）→ **MLB Stats API fetcher 的 endpoint shape 只能 VPS 驗**：platoon games（schedule + game log + pitchHand）、未來賽程（PA 投影）、discipline bulk CSV。全 best-effort 包（失敗 → 該注入缺，never abort scan）。

## 下一步：VPS A/B 段①（design doc）

batter 注入**裸上、prompt 不動**，跑真實 payload 配對 A/B：
- input token 漲在預期內、**output token 不暴增**（lever-2 thinking 誘發 = 核心驗證點）
- payload 視覺檢查 + fetcher endpoint shape
- 段① 數據決定 042 prompt 做不做

## 第二批（B6/B7，待段① 後）

- **B6 SP 注入**（`slim_entry` JSON 欄位；SP prompt 隔離成獨立 HITL slice）
- **B7 legacy backfill**（前置腳本；roster 用 tagged `add_reason`，非 verdict sentinel）

決策依據：3-agent review 一致推 (b) + design doc，詳見 commit `e30377c`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
